### PR TITLE
adding companys information

### DIFF
--- a/app/tickers/[ticker]/CompanyInfo.tsx
+++ b/app/tickers/[ticker]/CompanyInfo.tsx
@@ -1,47 +1,48 @@
 'use client'
+import { KeyStatsType } from './KeyStats'
 import { useState } from 'react'
 
-export type CompanyInfoType = {
-  name: string
-  sector: string
-  industry: string
-  description: string
-  country: string
+type CompanyInfoType = Pick<
+  KeyStatsType,
+  'name' | 'sector' | 'industry' | 'country' | 'description'
+>
+function toTitleCase(str: string) {
+  return str.toLowerCase().replace(/\b\w/g, (char) => char.toUpperCase())
 }
 
 export default function CompanyInfo({ companyInfo }: { companyInfo: CompanyInfoType }) {
   const [showMore, setShowMore] = useState(false)
   const maxLength = 200
   const toggleShowMore = () => setShowMore((prev) => !prev)
-  const shortcut = companyInfo.description.length > maxLength
+  const needsTruncate = companyInfo.description.length > maxLength
   const displayed = showMore
     ? companyInfo.description
-    : companyInfo.description.slice(0, maxLength) + (shortcut ? '...' : '')
+    : companyInfo.description.slice(0, maxLength) + (needsTruncate ? '...' : '')
   return (
-    <section className="m-4">
-      <h2 className="text-xl font-bold mb-4">About {companyInfo.name}</h2>
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-lg">
+    <section className="mt-2 mb-6">
+      <h2 className="text-xl font-bold mb-2">About {companyInfo.name}</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-lg mb-2">
         <div>
-          <span className="font-semibold">Sector:</span> <span>{companyInfo.sector}</span>
+          <span className="font-semibold">Sector:</span>{' '}
+          <span>{toTitleCase(companyInfo.sector)}</span>
         </div>
         <div>
-          <span className="font-semibold">Industry:</span> <span>{companyInfo.industry}</span>
+          <span className="font-semibold">Industry:</span>{' '}
+          <span>{toTitleCase(companyInfo.industry)}</span>
         </div>
         <div>
           <span className="font-semibold">Country:</span> <span>{companyInfo.country}</span>
         </div>
       </div>
-      <p className="mt-5 text-lg leading-relaxed">
+      <p className="text-lg leading-relaxed">
         {displayed}
-        {shortcut && (
+        {needsTruncate && (
           <button
             onClick={toggleShowMore}
-            className="ml-2 text-blue-500 hover:underline focus:outline-none"
+            className="text-blue-300 hover:underline focus:outline-none"
             aria-expanded={showMore}
-            aria-label={showMore ? 'Show less' : 'Show more'}
-            type="button"
           >
-            {showMore ? 'Show less' : 'Show more'}
+            {showMore ? 'Show Less' : 'Show More'}
           </button>
         )}
       </p>

--- a/app/tickers/[ticker]/CompanyInfo.tsx
+++ b/app/tickers/[ticker]/CompanyInfo.tsx
@@ -1,0 +1,50 @@
+'use client'
+import { useState } from 'react'
+
+export type CompanyInfoType = {
+  name: string
+  sector: string
+  industry: string
+  description: string
+  country: string
+}
+
+export default function CompanyInfo({ companyInfo }: { companyInfo: CompanyInfoType }) {
+  const [showMore, setShowMore] = useState(false)
+  const maxLength = 200
+  const toggleShowMore = () => setShowMore((prev) => !prev)
+  const shortcut = companyInfo.description.length > maxLength
+  const displayed = showMore
+    ? companyInfo.description
+    : companyInfo.description.slice(0, maxLength) + (shortcut ? '...' : '')
+  return (
+    <section className="m-4">
+      <h2 className="text-xl font-bold mb-4">About {companyInfo.name}</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-lg">
+        <div>
+          <span className="font-semibold">Sector:</span> <span>{companyInfo.sector}</span>
+        </div>
+        <div>
+          <span className="font-semibold">Industry:</span> <span>{companyInfo.industry}</span>
+        </div>
+        <div>
+          <span className="font-semibold">Country:</span> <span>{companyInfo.country}</span>
+        </div>
+      </div>
+      <p className="mt-5 text-lg leading-relaxed">
+        {displayed}
+        {shortcut && (
+          <button
+            onClick={toggleShowMore}
+            className="ml-2 text-blue-500 hover:underline focus:outline-none"
+            aria-expanded={showMore}
+            aria-label={showMore ? 'Show less' : 'Show more'}
+            type="button"
+          >
+            {showMore ? 'Show less' : 'Show more'}
+          </button>
+        )}
+      </p>
+    </section>
+  )
+}

--- a/app/tickers/[ticker]/CompanyInfo.tsx
+++ b/app/tickers/[ticker]/CompanyInfo.tsx
@@ -1,36 +1,45 @@
 'use client'
-import type { KeyStatsType } from '@/app/types'
 import { useState } from 'react'
 
-function toTitleCase(str: string) {
-  if (!str) return ' '
-  return str.toLowerCase().replace(/\b\w/g, (char) => char.toUpperCase())
+type CompanyInfoType = {
+  name: string
+  sector: string
+  industry: string
+  description?: string
+  country: string
 }
 
-export default function CompanyInfo({ companyInfo }: { companyInfo: KeyStatsType }) {
+function toTitleCase(str?: string) {
+  if (!str) return ''
+  return str.toLowerCase().replace(/\b\w/g, (char) => char.toUpperCase())
+}
+export default function CompanyInfo({ companyInfo }: { companyInfo: CompanyInfoType }) {
   const [showMore, setShowMore] = useState(false)
   const maxLength = 200
   const toggleShowMore = () => setShowMore((prev) => !prev)
-  const des = companyInfo.description || ' '
+  const des = companyInfo?.description?.trim() ?? ''
   const needsTruncate = des.length > maxLength
-  const displayed = showMore ? des : des.slice(0, maxLength) + (needsTruncate ? '...  ' : ' ')
+  const displayed = showMore ? des + ' ' : des.slice(0, maxLength) + (needsTruncate ? '... ' : '')
 
   return (
     <section className="mt-2 mb-6">
       <h2 className="text-xl font-bold mb-2">About {companyInfo.name}</h2>
+
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-lg mb-2">
         <div>
-          <span className="font-semibold">Sector:</span>{' '}
+          <span className="font-semibold">Sector: </span>
           <span>{toTitleCase(companyInfo.sector)}</span>
         </div>
         <div>
-          <span className="font-semibold">Industry:</span>{' '}
+          <span className="font-semibold">Industry: </span>
           <span>{toTitleCase(companyInfo.industry)}</span>
         </div>
         <div>
-          <span className="font-semibold">Country:</span> <span>{companyInfo.country}</span>
+          <span className="font-semibold">Country: </span>
+          <span>{companyInfo.country}</span>
         </div>
       </div>
+
       <p className="text-lg leading-relaxed">
         {displayed}
         {needsTruncate && (

--- a/app/tickers/[ticker]/CompanyInfo.tsx
+++ b/app/tickers/[ticker]/CompanyInfo.tsx
@@ -1,23 +1,20 @@
 'use client'
-import { KeyStatsType } from './KeyStats'
+import type { KeyStatsType } from '@/app/types'
 import { useState } from 'react'
 
-type CompanyInfoType = Pick<
-  KeyStatsType,
-  'name' | 'sector' | 'industry' | 'country' | 'description'
->
 function toTitleCase(str: string) {
+  if (!str) return ' '
   return str.toLowerCase().replace(/\b\w/g, (char) => char.toUpperCase())
 }
 
-export default function CompanyInfo({ companyInfo }: { companyInfo: CompanyInfoType }) {
+export default function CompanyInfo({ companyInfo }: { companyInfo: KeyStatsType }) {
   const [showMore, setShowMore] = useState(false)
   const maxLength = 200
   const toggleShowMore = () => setShowMore((prev) => !prev)
-  const needsTruncate = companyInfo.description.length > maxLength
-  const displayed = showMore
-    ? companyInfo.description
-    : companyInfo.description.slice(0, maxLength) + (needsTruncate ? '...' : '')
+  const des = companyInfo.description || ' '
+  const needsTruncate = des.length > maxLength
+  const displayed = showMore ? des : des.slice(0, maxLength) + (needsTruncate ? '...  ' : ' ')
+
   return (
     <section className="mt-2 mb-6">
       <h2 className="text-xl font-bold mb-2">About {companyInfo.name}</h2>
@@ -41,6 +38,7 @@ export default function CompanyInfo({ companyInfo }: { companyInfo: CompanyInfoT
             onClick={toggleShowMore}
             className="text-blue-300 hover:underline focus:outline-none"
             aria-expanded={showMore}
+            aria-label={showMore ? 'Show Less' : 'Show More'}
           >
             {showMore ? 'Show Less' : 'Show More'}
           </button>

--- a/app/tickers/[ticker]/page.tsx
+++ b/app/tickers/[ticker]/page.tsx
@@ -7,6 +7,7 @@ import DebtEquityChart from './DebtEquityChart'
 import { CompanyFinancialStatement } from '@/app/types'
 import { Company } from '@/app/CompanyList'
 import PriceChart from './PriceChart'
+import CompanyInfo from './CompanyInfo'
 
 export const revalidate = 120
 
@@ -79,6 +80,7 @@ export default async function TickerDetails({ params }: { params: Promise<{ tick
 
   return (
     <>
+      {keyStats && <CompanyInfo companyInfo={keyStats} />}
       <Suspense fallback={<p>Loading stock price chart</p>}>
         <PriceChart ticker={ticker} />
       </Suspense>

--- a/app/types.ts
+++ b/app/types.ts
@@ -31,12 +31,3 @@ export function isQuarterlyStatement(
 ): statement is QuarterlyFinancialStatement {
   return 'period_end_quarter' in statement
 }
-
-//KeyStats type
-export type KeyStatsType = {
-  name: string
-  sector: string
-  industry: string
-  country: string
-  description: string
-}

--- a/app/types.ts
+++ b/app/types.ts
@@ -31,3 +31,12 @@ export function isQuarterlyStatement(
 ): statement is QuarterlyFinancialStatement {
   return 'period_end_quarter' in statement
 }
+
+//KeyStats type
+export type KeyStatsType = {
+  name: string
+  sector: string
+  industry: string
+  country: string
+  description: string
+}


### PR DESCRIPTION
## Description
Adds a company background section to the ticker details page. Introduces a new client component `CompanyInfor.tsx` to display company name, sector, industry, country, and description with a “Show more/less” toggle (200-char truncate by default). Integrates this section at the top of `app/tickers/[ticker]/page.tsx`, rendering when `keyStats` is available.
Motivation: Give users quick, readable context about the company alongside financial charts and stats.

## Screenshot
<img width="1679" height="912" alt="Screenshot 2025-08-09 at 10 57 24" src="https://github.com/user-attachments/assets/68119e52-759c-46a2-9628-4ea75f1054c8" />

<img width="1678" height="908" alt="Screenshot 2025-08-09 at 10 57 36" src="https://github.com/user-attachments/assets/160c2d38-60b4-4e59-ba18-39937603a936" />

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## How to test
1. Navigate to a ticker page, e.g. `/tickers/AAPL`.
2. Verify an “About {Company}” section appears above the price chart when `keyStats` loads.
3. Confirm sector, industry, and country display correctly.
4. Check description truncates at ~200 characters with a “Show more” button.
5. Click “Show more/Show less” to verify toggle behavior and that ARIA attributes update (`aria-expanded`).
6. Test a few other tickers with longer descriptions to confirm truncation and layout hold up on mobile and desktop.
7. Confirm existing charts and stats still render as before and no new console warnings are introduced.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context
- The new component expects `name`, `sector`, `industry`, `country`, and `description` fields from the same data used for `keyStats`. If any field is missing in backend data, consider adding a fallback or mapping.
- File: `app/tickers/[ticker]/CompanyInfor.tsx` (client component) and integration in `app/tickers/[ticker]/page.tsx`.
- I scanned the updated files to capture the change and its intent.
- Provided a filled PR form highlighting the new About section, component details, and clear test steps.
