### PR TITLE
Refactor visual block streaming to marker-based approach

### DIFF
--- a/app/components/AnswerContent.tsx
+++ b/app/components/AnswerContent.tsx
@@ -1,48 +1,102 @@
 'use client'
 
-import { useMemo } from 'react'
 import MarkdownContent from './MarkdownContent'
 import SvgBlock from './SvgBlock'
 import HtmlIframe from './HtmlIframe'
-import { parseVisualBlocks } from './utils/parseVisualBlocks'
+import { VisualBlock } from './hooks/useChatState'
 
 interface AnswerContentProps {
   content: string
-  isStreaming?: boolean
+  visualBlocks?: VisualBlock[]
   smallSize?: boolean
+}
+
+type RenderPart = { type: 'text'; content: string } | { type: 'visual'; blockId: string }
+
+const VISUAL_MARKER_RE = /\[\[VISUAL_BLOCK:([a-zA-Z0-9_-]+)\]\]/g
+
+function splitByVisualMarkers(content: string): RenderPart[] {
+  if (!content) return []
+
+  const parts: RenderPart[] = []
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  while ((match = VISUAL_MARKER_RE.exec(content)) !== null) {
+    if (match.index > lastIndex) {
+      const text = content.slice(lastIndex, match.index)
+      if (text) {
+        parts.push({ type: 'text', content: text })
+      }
+    }
+
+    parts.push({ type: 'visual', blockId: match[1] })
+    lastIndex = match.index + match[0].length
+  }
+
+  if (lastIndex < content.length) {
+    const text = content.slice(lastIndex)
+    if (text) {
+      parts.push({ type: 'text', content: text })
+    }
+  }
+
+  if (parts.length === 0 && content) {
+    parts.push({ type: 'text', content })
+  }
+
+  return parts
 }
 
 export default function AnswerContent({
   content,
-  isStreaming = false,
+  visualBlocks = [],
   smallSize = false,
 }: AnswerContentProps) {
-  const { blocks, pendingVisual } = useMemo(
-    () => parseVisualBlocks(content, isStreaming),
-    [content, isStreaming],
-  )
+  const parts = splitByVisualMarkers(content)
+  const blockMap = new Map(visualBlocks.map((block) => [block.blockId, block]))
 
-  // If only text blocks and no pending visual, render as single MarkdownContent for consistency
-  if (blocks.length === 1 && blocks[0].type === 'text' && !pendingVisual) {
-    return <MarkdownContent content={blocks[0].content} smallSize={smallSize} />
+  // Fast path for simple text-only responses
+  if (!content.includes('[[VISUAL_BLOCK:')) {
+    return <MarkdownContent content={content} smallSize={smallSize} />
   }
 
   return (
     <div>
-      {blocks.map((block, i) => {
-        if (block.type === 'text') {
-          return <MarkdownContent key={i} content={block.content} smallSize={smallSize} />
+      {parts.map((part, i) => {
+        if (part.type === 'text') {
+          return <MarkdownContent key={`text-${i}`} content={part.content} smallSize={smallSize} />
         }
-        if (block.lang === 'svg') {
-          return <SvgBlock key={i} content={block.content} />
+
+        const visual = blockMap.get(part.blockId)
+        if (!visual || visual.status === 'streaming') {
+          return (
+            <div
+              key={`visual-${part.blockId}`}
+              className="my-4 h-32 bg-gray-100 dark:bg-gray-800 rounded-lg animate-pulse flex items-center justify-center text-sm text-gray-500"
+            >
+              Rendering visual...
+            </div>
+          )
         }
-        return <HtmlIframe key={i} content={block.content} />
+
+        if (visual.status === 'error') {
+          return (
+            <div
+              key={`visual-${part.blockId}`}
+              className="my-4 rounded-lg border border-red-200 bg-red-50 text-red-700 dark:border-red-900/50 dark:bg-red-900/20 dark:text-red-300 px-4 py-3 text-sm"
+            >
+              {visual.errorMessage || 'Failed to render visual content.'}
+            </div>
+          )
+        }
+
+        if (visual.lang === 'svg') {
+          return <SvgBlock key={`visual-${part.blockId}`} content={visual.content} />
+        }
+
+        return <HtmlIframe key={`visual-${part.blockId}`} content={visual.content} />
       })}
-      {pendingVisual && (
-        <div className="my-4 h-32 bg-gray-100 dark:bg-gray-800 rounded-lg animate-pulse flex items-center justify-center text-sm text-gray-500">
-          Rendering visual...
-        </div>
-      )}
     </div>
   )
 }

--- a/app/components/AnswerContent.tsx
+++ b/app/components/AnswerContent.tsx
@@ -13,16 +13,15 @@ interface AnswerContentProps {
 
 type RenderPart = { type: 'text'; content: string } | { type: 'visual'; blockId: string }
 
-const VISUAL_MARKER_RE = /\[\[VISUAL_BLOCK:([a-zA-Z0-9_-]+)\]\]/g
-
 function splitByVisualMarkers(content: string): RenderPart[] {
   if (!content) return []
 
+  const re = /\[\[VISUAL_BLOCK:([a-zA-Z0-9_-]+)\]\]/g
   const parts: RenderPart[] = []
   let lastIndex = 0
   let match: RegExpExecArray | null
 
-  while ((match = VISUAL_MARKER_RE.exec(content)) !== null) {
+  while ((match = re.exec(content)) !== null) {
     if (match.index > lastIndex) {
       const text = content.slice(lastIndex, match.index)
       if (text) {
@@ -39,10 +38,6 @@ function splitByVisualMarkers(content: string): RenderPart[] {
     if (text) {
       parts.push({ type: 'text', content: text })
     }
-  }
-
-  if (parts.length === 0 && content) {
-    parts.push({ type: 'text', content })
   }
 
   return parts

--- a/app/components/Chat.tsx
+++ b/app/components/Chat.tsx
@@ -120,8 +120,8 @@ const ThreadView: React.FC<ThreadViewProps> = ({
         </div>
       )}
       {/* Only show answer for normal threads */}
-      {isNormalThread(thread) && thread.answer && (
-        <AnswerContent content={thread.answer} isStreaming={isLastThread && isThinking} />
+      {isNormalThread(thread) && (thread.answer || thread.visualBlocks.length > 0) && (
+        <AnswerContent content={thread.answer || ''} visualBlocks={thread.visualBlocks} />
       )}
 
       {/* Show sources (grouped citations from answer) */}

--- a/app/components/__tests__/AnswerContent.test.tsx
+++ b/app/components/__tests__/AnswerContent.test.tsx
@@ -69,4 +69,31 @@ describe('AnswerContent', () => {
     render(<AnswerContent content={content} visualBlocks={visualBlocks} />)
     expect(screen.getByText('Could not render chart.')).toBeInTheDocument()
   })
+
+  it('shows fallback error text when error block has no errorMessage', () => {
+    const content = '[[VISUAL_BLOCK:vis_1]]'
+    const visualBlocks: VisualBlock[] = [
+      { blockId: 'vis_1', lang: 'html', content: '', status: 'error' },
+    ]
+    render(<AnswerContent content={content} visualBlocks={visualBlocks} />)
+    expect(screen.getByText('Failed to render visual content.')).toBeInTheDocument()
+  })
+
+  it('shows skeleton when marker blockId is not in visualBlocks', () => {
+    const content = '[[VISUAL_BLOCK:vis_unknown]]'
+    render(<AnswerContent content={content} visualBlocks={[]} />)
+    expect(screen.getByText('Rendering visual...')).toBeInTheDocument()
+  })
+
+  it('renders multiple visual blocks with interleaved text', () => {
+    const content = 'Intro\n\n[[VISUAL_BLOCK:vis_1]]\n\nMiddle\n\n[[VISUAL_BLOCK:vis_2]]\n\nEnd'
+    const visualBlocks: VisualBlock[] = [
+      { blockId: 'vis_1', lang: 'svg', content: '<svg>A</svg>', status: 'done' },
+      { blockId: 'vis_2', lang: 'html', content: '<div>B</div>', status: 'done' },
+    ]
+    render(<AnswerContent content={content} visualBlocks={visualBlocks} />)
+    expect(screen.getAllByTestId('markdown')).toHaveLength(3)
+    expect(screen.getByTestId('svg-block')).toBeInTheDocument()
+    expect(screen.getByTestId('html-iframe')).toBeInTheDocument()
+  })
 })

--- a/app/components/__tests__/AnswerContent.test.tsx
+++ b/app/components/__tests__/AnswerContent.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@/tests/test-utils'
 import { vi, describe, it, expect } from 'vitest'
 import AnswerContent from '../AnswerContent'
+import { VisualBlock } from '../hooks/useChatState'
 
 vi.mock('dompurify', () => ({
   default: { sanitize: (_: string, __: unknown) => _ },
@@ -25,37 +26,47 @@ describe('AnswerContent', () => {
     expect(screen.queryByTestId('svg-block')).not.toBeInTheDocument()
   })
 
-  it('renders SVG block', () => {
-    const content = 'Before\n\n```svg\n<svg></svg>\n```\n\nAfter'
-    render(<AnswerContent content={content} />)
+  it('renders SVG block when marker is completed', () => {
+    const content = 'Before\n\n[[VISUAL_BLOCK:vis_1]]\n\nAfter'
+    const visualBlocks: VisualBlock[] = [
+      { blockId: 'vis_1', lang: 'svg', content: '<svg></svg>', status: 'done' },
+    ]
+    render(<AnswerContent content={content} visualBlocks={visualBlocks} />)
     expect(screen.getByTestId('svg-block')).toBeInTheDocument()
     expect(screen.getAllByTestId('markdown')).toHaveLength(2)
   })
 
-  it('renders HTML iframe', () => {
-    const content = 'Intro\n\n```html\n<div>chart</div>\n```'
-    render(<AnswerContent content={content} />)
+  it('renders HTML iframe when marker is completed', () => {
+    const content = 'Intro\n\n[[VISUAL_BLOCK:vis_1]]'
+    const visualBlocks: VisualBlock[] = [
+      { blockId: 'vis_1', lang: 'html', content: '<div>chart</div>', status: 'done' },
+    ]
+    render(<AnswerContent content={content} visualBlocks={visualBlocks} />)
     expect(screen.getByTestId('html-iframe')).toBeInTheDocument()
   })
 
-  it('shows loading skeleton when text precedes a streaming visual', () => {
-    // Text before an unclosed html fence — fast-path must NOT fire
-    const content = 'Here is the chart:\n\n```html\n<div>partial'
-    render(<AnswerContent content={content} isStreaming={true} />)
+  it('shows loading skeleton when visual block is still streaming', () => {
+    const content = 'Here is the chart:\n\n[[VISUAL_BLOCK:vis_1]]'
+    const visualBlocks: VisualBlock[] = [
+      { blockId: 'vis_1', lang: 'html', content: '<div>partial', status: 'streaming' },
+    ]
+    render(<AnswerContent content={content} visualBlocks={visualBlocks} />)
     expect(screen.getByText('Rendering visual...')).toBeInTheDocument()
-    // The preceding text is still rendered
     expect(screen.getByTestId('markdown')).toBeInTheDocument()
   })
 
-  it('does NOT show skeleton for plain text with no pending visual', () => {
-    render(<AnswerContent content="Just text" isStreaming={true} />)
-    expect(screen.queryByText('Rendering visual...')).not.toBeInTheDocument()
-  })
-
-  it('does NOT show skeleton after streaming completes', () => {
-    const content = 'Here is the chart:\n\n```html\n<div>complete</div>\n```'
-    render(<AnswerContent content={content} isStreaming={false} />)
-    expect(screen.queryByText('Rendering visual...')).not.toBeInTheDocument()
-    expect(screen.getByTestId('html-iframe')).toBeInTheDocument()
+  it('shows visual error message when block fails', () => {
+    const content = '[[VISUAL_BLOCK:vis_1]]'
+    const visualBlocks: VisualBlock[] = [
+      {
+        blockId: 'vis_1',
+        lang: 'html',
+        content: '',
+        status: 'error',
+        errorMessage: 'Could not render chart.',
+      },
+    ]
+    render(<AnswerContent content={content} visualBlocks={visualBlocks} />)
+    expect(screen.getByText('Could not render chart.')).toBeInTheDocument()
   })
 })

--- a/app/components/hooks/useChatAPI.ts
+++ b/app/components/hooks/useChatAPI.ts
@@ -66,7 +66,6 @@ export const useChatAPI = (
       let relatedQuestions: string[] = []
       let grounds: AnswerGround[] = []
       let visualBlocks: VisualBlock[] = []
-      let visualOrder: string[] = []
       let buffer = ''
 
       const upsertVisualBlock = (
@@ -127,19 +126,16 @@ export const useChatAPI = (
             isThinkingRef.current = false
           }
 
-          const body = (parsedChunk.body || {}) as { block_id?: string; lang?: VisualLang }
+          const body = (parsedChunk.body || {}) as { block_id?: string; lang?: string }
           if (!body.block_id || !body.lang) return
+          if (!(['svg', 'html'] as string[]).includes(body.lang)) return
 
           upsertVisualBlock(body.block_id, {
             blockId: body.block_id,
-            lang: body.lang,
+            lang: body.lang as VisualLang,
             status: 'streaming',
             content: '',
           })
-
-          if (!visualOrder.includes(body.block_id)) {
-            visualOrder = [...visualOrder, body.block_id]
-          }
 
           const markerToken = `[[VISUAL_BLOCK:${body.block_id}]]`
           if (!accumulatedContent.includes(markerToken)) {
@@ -149,7 +145,6 @@ export const useChatAPI = (
           updateThread(threadId, {
             answer: accumulatedContent,
             visualBlocks,
-            visualOrder,
           })
           return
         }
@@ -166,36 +161,27 @@ export const useChatAPI = (
             lang: existing?.lang || 'html',
           })
 
-          updateThread(threadId, {
-            visualBlocks,
-            visualOrder,
-          })
+          updateThread(threadId, { visualBlocks })
           return
         }
 
         if (parsedChunk.type === 'answer_visual_done') {
           const body = (parsedChunk.body || {}) as {
             block_id?: string
-            lang?: VisualLang
+            lang?: string
             content?: string
           }
           if (!body.block_id || !body.lang) return
+          if (!(['svg', 'html'] as string[]).includes(body.lang)) return
 
           upsertVisualBlock(body.block_id, {
             blockId: body.block_id,
-            lang: body.lang,
+            lang: body.lang as VisualLang,
             content: body.content || '',
             status: 'done',
           })
 
-          if (!visualOrder.includes(body.block_id)) {
-            visualOrder = [...visualOrder, body.block_id]
-          }
-
-          updateThread(threadId, {
-            visualBlocks,
-            visualOrder,
-          })
+          updateThread(threadId, { visualBlocks })
           return
         }
 
@@ -212,7 +198,7 @@ export const useChatAPI = (
             content: existing?.content || '',
           })
 
-          updateThread(threadId, { visualBlocks, visualOrder })
+          updateThread(threadId, { visualBlocks })
           return
         }
 
@@ -322,7 +308,6 @@ export const useChatAPI = (
           thoughts: [],
           relatedQuestions: [],
           visualBlocks: [],
-          visualOrder: [],
         })
         return
       }
@@ -333,7 +318,6 @@ export const useChatAPI = (
         thoughts: [],
         relatedQuestions: [],
         visualBlocks: [],
-        visualOrder: [],
       })
     } finally {
       setIsLoading(false)

--- a/app/components/hooks/useChatAPI.ts
+++ b/app/components/hooks/useChatAPI.ts
@@ -1,6 +1,17 @@
 import { useRef, useState } from 'react'
-import { AnswerGround, AnswerSource, Thread } from './useChatState'
+import { AnswerGround, AnswerSource, Thread, VisualBlock } from './useChatState'
 import { chatService } from '../services/chatService'
+
+type VisualLang = 'html' | 'svg'
+
+type StreamChunk = {
+  type: string
+  body?: unknown
+  url?: string
+  title?: string
+}
+
+const visualMarker = (blockId: string) => `\n\n[[VISUAL_BLOCK:${blockId}]]\n\n`
 
 export const useChatAPI = (
   ticker: string | undefined,
@@ -54,7 +65,225 @@ export const useChatAPI = (
       let thoughts: string[] = []
       let relatedQuestions: string[] = []
       let grounds: AnswerGround[] = []
+      let visualBlocks: VisualBlock[] = []
+      let visualOrder: string[] = []
       let buffer = ''
+
+      const upsertVisualBlock = (
+        blockId: string,
+        updates: Partial<VisualBlock> & Pick<VisualBlock, 'blockId'>,
+      ) => {
+        const existingIndex = visualBlocks.findIndex((b) => b.blockId === blockId)
+        if (existingIndex === -1) {
+          const next: VisualBlock = {
+            blockId,
+            lang: (updates.lang as VisualLang) || 'html',
+            content: updates.content || '',
+            status: updates.status || 'streaming',
+            errorMessage: updates.errorMessage,
+          }
+          visualBlocks = [...visualBlocks, next]
+          return
+        }
+
+        const existing = visualBlocks[existingIndex]
+        const merged: VisualBlock = {
+          ...existing,
+          ...updates,
+          blockId,
+          lang: (updates.lang as VisualLang) || existing.lang,
+        }
+        visualBlocks = [
+          ...visualBlocks.slice(0, existingIndex),
+          merged,
+          ...visualBlocks.slice(existingIndex + 1),
+        ]
+      }
+
+      const handleParsedChunk = (parsedChunk: StreamChunk) => {
+        if (parsedChunk.type === 'conversation') {
+          // Handle conversation event - store conversationId
+          const body = (parsedChunk.body || {}) as { conversationId?: string }
+          const newConversationId = body.conversationId || null
+          if (newConversationId) {
+            setConversationId(newConversationId)
+            // Record activity when conversation is established
+            recordActivity()
+          }
+          return
+        }
+
+        if (parsedChunk.type === 'answer') {
+          if (isThinkingRef.current) {
+            isThinkingRef.current = false
+          }
+          accumulatedContent += String(parsedChunk.body || '')
+          updateThread(threadId, { answer: accumulatedContent })
+          return
+        }
+
+        if (parsedChunk.type === 'answer_visual_start') {
+          if (isThinkingRef.current) {
+            isThinkingRef.current = false
+          }
+
+          const body = (parsedChunk.body || {}) as { block_id?: string; lang?: VisualLang }
+          if (!body.block_id || !body.lang) return
+
+          upsertVisualBlock(body.block_id, {
+            blockId: body.block_id,
+            lang: body.lang,
+            status: 'streaming',
+            content: '',
+          })
+
+          if (!visualOrder.includes(body.block_id)) {
+            visualOrder = [...visualOrder, body.block_id]
+          }
+
+          const markerToken = `[[VISUAL_BLOCK:${body.block_id}]]`
+          if (!accumulatedContent.includes(markerToken)) {
+            accumulatedContent += visualMarker(body.block_id)
+          }
+
+          updateThread(threadId, {
+            answer: accumulatedContent,
+            visualBlocks,
+            visualOrder,
+          })
+          return
+        }
+
+        if (parsedChunk.type === 'answer_visual_delta') {
+          const body = (parsedChunk.body || {}) as { block_id?: string; delta?: string }
+          if (!body.block_id) return
+
+          const existing = visualBlocks.find((b) => b.blockId === body.block_id)
+          upsertVisualBlock(body.block_id, {
+            blockId: body.block_id,
+            status: existing?.status || 'streaming',
+            content: `${existing?.content || ''}${body.delta || ''}`,
+            lang: existing?.lang || 'html',
+          })
+
+          updateThread(threadId, {
+            visualBlocks,
+            visualOrder,
+          })
+          return
+        }
+
+        if (parsedChunk.type === 'answer_visual_done') {
+          const body = (parsedChunk.body || {}) as {
+            block_id?: string
+            lang?: VisualLang
+            content?: string
+          }
+          if (!body.block_id || !body.lang) return
+
+          upsertVisualBlock(body.block_id, {
+            blockId: body.block_id,
+            lang: body.lang,
+            content: body.content || '',
+            status: 'done',
+          })
+
+          if (!visualOrder.includes(body.block_id)) {
+            visualOrder = [...visualOrder, body.block_id]
+          }
+
+          updateThread(threadId, {
+            visualBlocks,
+            visualOrder,
+          })
+          return
+        }
+
+        if (parsedChunk.type === 'answer_visual_error') {
+          const body = (parsedChunk.body || {}) as { block_id?: string; message?: string }
+          if (!body.block_id) return
+
+          const existing = visualBlocks.find((b) => b.blockId === body.block_id)
+          upsertVisualBlock(body.block_id, {
+            blockId: body.block_id,
+            status: 'error',
+            errorMessage: body.message || 'Failed to render visual block.',
+            lang: existing?.lang || 'html',
+            content: existing?.content || '',
+          })
+
+          updateThread(threadId, { visualBlocks, visualOrder })
+          return
+        }
+
+        if (parsedChunk.type === 'thinking_status') {
+          if (!isThinkingRef.current) {
+            isThinkingRef.current = true
+          }
+          thoughts = [...thoughts, String(parsedChunk.body || '')]
+          updateThread(threadId, { thoughts })
+          return
+        }
+
+        if (parsedChunk.type === 'related_question') {
+          relatedQuestions = [...relatedQuestions, String(parsedChunk.body || '')]
+          updateThread(threadId, { relatedQuestions })
+          return
+        }
+
+        if (parsedChunk.type === 'google_search_ground') {
+          grounds = [
+            ...grounds,
+            { body: String(parsedChunk.body || ''), url: String(parsedChunk.url || '') },
+          ]
+          updateThread(threadId, { grounds })
+          return
+        }
+
+        if (parsedChunk.type === 'sources') {
+          if (Array.isArray(parsedChunk.body)) {
+            const links = parsedChunk.body
+              .map((s: { name: string; url?: string }) =>
+                s.url ? `[${s.name}](${s.url})` : s.name,
+              )
+              .join(' ')
+            if (links) {
+              // Trim trailing newlines so links render inline with paragraph
+              const trimmed = accumulatedContent.replace(/\n+$/, '')
+              accumulatedContent = trimmed + ' ' + links + '\n\n'
+              updateThread(threadId, { answer: accumulatedContent })
+            }
+          }
+          return
+        }
+
+        if (parsedChunk.type === 'sources_grouped') {
+          const body = (parsedChunk.body || {}) as {
+            sources?: { name: string; url?: string; paragraph_indices?: number[] }[]
+          }
+          const groupedSources: AnswerSource[] = (body.sources || []).map((s) => ({
+            name: s.name,
+            url: s.url,
+            paragraphIndices: s.paragraph_indices,
+          }))
+          updateThread(threadId, { sources: groupedSources })
+          return
+        }
+
+        if (parsedChunk.type === 'model_used') {
+          updateThread(threadId, { modelName: String(parsedChunk.body || '') })
+          return
+        }
+
+        if (parsedChunk.type === 'attachment_url') {
+          updateThread(threadId, {
+            attachment: {
+              title: String(parsedChunk.title || 'Attachment'),
+              url: String(parsedChunk.body || ''),
+            },
+          })
+        }
+      }
 
       while (true) {
         const { value, done } = await reader.read()
@@ -69,66 +298,8 @@ export const useChatAPI = (
           const trimmed = line.trim()
           if (!trimmed) continue
           try {
-            const parsedChunk = JSON.parse(trimmed)
-            if (parsedChunk.type === 'conversation') {
-              // Handle conversation event - store conversationId
-              const newConversationId = parsedChunk.body?.conversationId || null
-              if (newConversationId) {
-                setConversationId(newConversationId)
-                // Record activity when conversation is established
-                recordActivity()
-              }
-            } else if (parsedChunk.type === 'answer') {
-              if (isThinkingRef.current) {
-                isThinkingRef.current = false
-              }
-              accumulatedContent += parsedChunk.body
-              updateThread(threadId, { answer: accumulatedContent })
-            } else if (parsedChunk.type === 'thinking_status') {
-              if (!isThinkingRef.current) {
-                isThinkingRef.current = true
-              }
-              thoughts = [...thoughts, parsedChunk.body]
-              updateThread(threadId, { thoughts })
-            } else if (parsedChunk.type === 'related_question') {
-              relatedQuestions = [...relatedQuestions, parsedChunk.body]
-              updateThread(threadId, { relatedQuestions })
-            } else if (parsedChunk.type === 'google_search_ground') {
-              grounds = [...grounds, { body: parsedChunk.body, url: parsedChunk.url }]
-              updateThread(threadId, { grounds })
-            } else if (parsedChunk.type === 'sources') {
-              if (Array.isArray(parsedChunk.body)) {
-                const links = parsedChunk.body
-                  .map((s: { name: string; url?: string }) =>
-                    s.url ? `[${s.name}](${s.url})` : s.name,
-                  )
-                  .join(' ')
-                if (links) {
-                  // Trim trailing newlines so links render inline with paragraph
-                  const trimmed = accumulatedContent.replace(/\n+$/, '')
-                  accumulatedContent = trimmed + ' ' + links + '\n\n'
-                  updateThread(threadId, { answer: accumulatedContent })
-                }
-              }
-            } else if (parsedChunk.type === 'sources_grouped') {
-              const groupedSources: AnswerSource[] = (parsedChunk.body?.sources || []).map(
-                (s: { name: string; url?: string; paragraph_indices?: number[] }) => ({
-                  name: s.name,
-                  url: s.url,
-                  paragraphIndices: s.paragraph_indices,
-                }),
-              )
-              updateThread(threadId, { sources: groupedSources })
-            } else if (parsedChunk.type === 'model_used') {
-              updateThread(threadId, { modelName: parsedChunk.body })
-            } else if (parsedChunk.type === 'attachment_url') {
-              updateThread(threadId, {
-                attachment: {
-                  title: parsedChunk.title || 'Attachment',
-                  url: parsedChunk.body,
-                },
-              })
-            }
+            const parsedChunk = JSON.parse(trimmed) as StreamChunk
+            handleParsedChunk(parsedChunk)
           } catch (e) {
             console.error('Error parsing chunk:', e)
           }
@@ -138,21 +309,8 @@ export const useChatAPI = (
       // Process any remaining buffer
       if (buffer.trim()) {
         try {
-          const parsedChunk = JSON.parse(buffer.trim())
-          if (parsedChunk.type === 'sources' && Array.isArray(parsedChunk.body)) {
-            const links = parsedChunk.body
-              .map((s: { name: string; url?: string }) =>
-                s.url ? `[${s.name}](${s.url})` : s.name,
-              )
-              .join(' ')
-            if (links) {
-              const trimmed = accumulatedContent.replace(/\n+$/, '')
-              accumulatedContent = trimmed + ' ' + links + '\n\n'
-              updateThread(threadId, { answer: accumulatedContent })
-            }
-          } else if (parsedChunk.type === 'model_used') {
-            updateThread(threadId, { modelName: parsedChunk.body })
-          }
+          const parsedChunk = JSON.parse(buffer.trim()) as StreamChunk
+          handleParsedChunk(parsedChunk)
         } catch (e) {
           console.error('Error parsing remaining buffer:', e)
         }
@@ -163,6 +321,8 @@ export const useChatAPI = (
           answer: 'Request cancelled.',
           thoughts: [],
           relatedQuestions: [],
+          visualBlocks: [],
+          visualOrder: [],
         })
         return
       }
@@ -172,6 +332,8 @@ export const useChatAPI = (
         answer: 'Sorry, I encountered an error analyzing the data.',
         thoughts: [],
         relatedQuestions: [],
+        visualBlocks: [],
+        visualOrder: [],
       })
     } finally {
       setIsLoading(false)

--- a/app/components/hooks/useChatState.ts
+++ b/app/components/hooks/useChatState.ts
@@ -11,6 +11,14 @@ export interface AnswerSource {
   paragraphIndices?: number[]
 }
 
+export interface VisualBlock {
+  blockId: string
+  lang: 'html' | 'svg'
+  content: string
+  status: 'streaming' | 'done' | 'error'
+  errorMessage?: string
+}
+
 export interface Attachment {
   title: string
   url: string
@@ -30,6 +38,8 @@ export interface NormalThread {
   relatedQuestions: string[]
   grounds: AnswerGround[]
   sources: AnswerSource[]
+  visualBlocks: VisualBlock[]
+  visualOrder: string[]
   modelName: string | undefined
   attachment: Attachment | undefined
 }
@@ -221,6 +231,8 @@ export const useChatState = (ticker: string | undefined) => {
       relatedQuestions: [],
       grounds: [],
       sources: [],
+      visualBlocks: [],
+      visualOrder: [],
       modelName: undefined,
       attachment: undefined,
     }
@@ -248,6 +260,8 @@ export const useChatState = (ticker: string | undefined) => {
             relatedQuestions: updates.relatedQuestions || [],
             grounds: (updates as Partial<NormalThread>).grounds || [],
             sources: (updates as Partial<NormalThread>).sources || [],
+            visualBlocks: (updates as Partial<NormalThread>).visualBlocks || [],
+            visualOrder: (updates as Partial<NormalThread>).visualOrder || [],
             modelName: (updates as Partial<NormalThread>).modelName || undefined,
             attachment: (updates as Partial<NormalThread>).attachment || undefined,
           }

--- a/app/components/hooks/useChatState.ts
+++ b/app/components/hooks/useChatState.ts
@@ -39,7 +39,6 @@ export interface NormalThread {
   grounds: AnswerGround[]
   sources: AnswerSource[]
   visualBlocks: VisualBlock[]
-  visualOrder: string[]
   modelName: string | undefined
   attachment: Attachment | undefined
 }
@@ -232,7 +231,6 @@ export const useChatState = (ticker: string | undefined) => {
       grounds: [],
       sources: [],
       visualBlocks: [],
-      visualOrder: [],
       modelName: undefined,
       attachment: undefined,
     }
@@ -261,7 +259,6 @@ export const useChatState = (ticker: string | undefined) => {
             grounds: (updates as Partial<NormalThread>).grounds || [],
             sources: (updates as Partial<NormalThread>).sources || [],
             visualBlocks: (updates as Partial<NormalThread>).visualBlocks || [],
-            visualOrder: (updates as Partial<NormalThread>).visualOrder || [],
             modelName: (updates as Partial<NormalThread>).modelName || undefined,
             attachment: (updates as Partial<NormalThread>).attachment || undefined,
           }


### PR DESCRIPTION
## Summary
- Replace fenced code block parsing (`\`\`\`svg`/`\`\`\`html`) with dedicated stream event types (`answer_visual_start`, `answer_visual_delta`, `answer_visual_done`, `answer_visual_error`)
- Visual blocks are tracked with `[[VISUAL_BLOCK:blockId]]` markers in the answer text
- Each block has status tracking (`streaming` | `done` | `error`) with per-block error display
- `AnswerContent` now accepts `visualBlocks` prop instead of `isStreaming` — decouples rendering from parsing
- Refactored `useChatAPI` chunk handler into a single `handleParsedChunk` function, eliminating the long if-else chain

## Test plan
- [ ] Unit tests updated and passing for `AnswerContent` (SVG, HTML, streaming skeleton, error state)
- [ ] Manual: ask a question that produces a chart — confirm streaming skeleton shows, then chart renders
- [ ] Manual: simulate visual error — confirm error message displays inline