### PR TITLE
Support non-US stocks in search and price chart

### DIFF
--- a/app/components/CompanySearch.tsx
+++ b/app/components/CompanySearch.tsx
@@ -79,9 +79,11 @@ const CompanySearch: React.FC<CompanySearchProps> = ({
     setSearchLoading(true)
     try {
       // TODO: move this to server side
-      const response = await fetch(
-        `https://finnhub.io/api/v1/search?q=${query}&token=${process.env.NEXT_PUBLIC_FINNHUB_API_KEY}`,
-      )
+      const params = new URLSearchParams({
+        q: query,
+        token: process.env.NEXT_PUBLIC_FINNHUB_API_KEY ?? '',
+      })
+      const response = await fetch(`https://finnhub.io/api/v1/search?${params}`)
       const data = await response.json()
 
       if (data.result) {

--- a/app/components/CompanySearch.tsx
+++ b/app/components/CompanySearch.tsx
@@ -80,16 +80,14 @@ const CompanySearch: React.FC<CompanySearchProps> = ({
     try {
       // TODO: move this to server side
       const response = await fetch(
-        `https://finnhub.io/api/v1/search?q=${query}&exchange=US&token=${process.env.NEXT_PUBLIC_FINNHUB_API_KEY}`,
+        `https://finnhub.io/api/v1/search?q=${query}&token=${process.env.NEXT_PUBLIC_FINNHUB_API_KEY}`,
       )
       const data = await response.json()
 
       if (data.result) {
         // Filter to only Common Stock type
         const results = data.result
-          .filter(
-            (match: FinnhubMatch) => match.type === 'Common Stock' && !match.symbol.includes('.'), // Exclude non-US exchanges
-          )
+          .filter((match: FinnhubMatch) => match.type === 'Common Stock')
           .map((match: FinnhubMatch) => ({
             symbol: match.symbol,
             name: match.description,
@@ -190,7 +188,7 @@ const CompanySearch: React.FC<CompanySearchProps> = ({
               value={inputValue}
               onChange={handleInputChange}
               onKeyDown={handleKeyDown}
-              placeholder="Enter stock ticker or company name (e.g. AAPL or Apple). Only US tickers are supported now."
+              placeholder="Enter stock ticker or company name (e.g. AAPL or Apple)"
               className="w-full px-4 py-2 text-base border border-gray-300 dark:border-gray-600 rounded-xl 
                          bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100
                          focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent

--- a/app/tickers/[ticker]/PriceChart.tsx
+++ b/app/tickers/[ticker]/PriceChart.tsx
@@ -10,9 +10,12 @@ const EXCHANGE_MAP: Record<string, string> = {
 function toTradingViewSymbol(ticker: string): string {
   const dotIndex = ticker.lastIndexOf('.')
   if (dotIndex === -1) return ticker
-  const suffix = ticker.slice(dotIndex + 1)
+  const suffix = ticker.slice(dotIndex + 1).toUpperCase()
   const exchange = EXCHANGE_MAP[suffix]
-  if (!exchange) return ticker
+  if (!exchange) {
+    console.warn(`[PriceChart] Unmapped exchange suffix: "${suffix}" for ticker "${ticker}"`)
+    return ticker
+  }
   return `${exchange}:${ticker.slice(0, dotIndex)}`
 }
 
@@ -32,6 +35,7 @@ function TradingViewWidget({ ticker }: { ticker: string }) {
       return
     }
 
+    const tvSymbol = toTradingViewSymbol(ticker)
     const widgetOptions = {
       lineWidth: 2,
       lineType: 0,
@@ -57,7 +61,7 @@ function TradingViewWidget({ ticker }: { ticker: string }) {
       fontFamily: '-apple-system, BlinkMacSystemFont, Trebuchet MS, Roboto, Ubuntu, sans-serif',
       valuesTracking: '1',
       changeMode: 'price-and-percent',
-      symbols: [[toTradingViewSymbol(ticker), `${toTradingViewSymbol(ticker)}|YTD`]],
+      symbols: [[tvSymbol, `${tvSymbol}|YTD`]],
       dateRanges: ['12m|1D', '60m|1W', 'ytd|1D', 'all|1M'],
       fontSize: '10',
       headerFontSize: 'medium',

--- a/app/tickers/[ticker]/PriceChart.tsx
+++ b/app/tickers/[ticker]/PriceChart.tsx
@@ -3,6 +3,19 @@
 import React, { useEffect, useRef, memo } from 'react'
 import { useDarkMode } from '../../components/hooks/useDarkMode'
 
+const EXCHANGE_MAP: Record<string, string> = {
+  HE: 'OMXHEX',
+}
+
+function toTradingViewSymbol(ticker: string): string {
+  const dotIndex = ticker.lastIndexOf('.')
+  if (dotIndex === -1) return ticker
+  const suffix = ticker.slice(dotIndex + 1)
+  const exchange = EXCHANGE_MAP[suffix]
+  if (!exchange) return ticker
+  return `${exchange}:${ticker.slice(0, dotIndex)}`
+}
+
 function TradingViewWidget({ ticker }: { ticker: string }) {
   const container = useRef<HTMLDivElement>(null)
   const hasCreatedChart = useRef<boolean>(false)
@@ -44,7 +57,7 @@ function TradingViewWidget({ ticker }: { ticker: string }) {
       fontFamily: '-apple-system, BlinkMacSystemFont, Trebuchet MS, Roboto, Ubuntu, sans-serif',
       valuesTracking: '1',
       changeMode: 'price-and-percent',
-      symbols: [[ticker, `${ticker}|YTD`]],
+      symbols: [[toTradingViewSymbol(ticker), `${toTradingViewSymbol(ticker)}|YTD`]],
       dateRanges: ['12m|1D', '60m|1W', 'ytd|1D', 'all|1M'],
       fontSize: '10',
       headerFontSize: 'medium',


### PR DESCRIPTION
## Summary
- Remove `exchange=US` param and dot-symbol filter from Finnhub search so non-US stocks appear in results
- Add `toTradingViewSymbol()` helper in `PriceChart.tsx` that maps Finnhub exchange suffixes to TradingView's `EXCHANGE:TICKER` format (e.g. `MANTA.HE` → `OMXHEX:MANTA`)
- Update search placeholder text to remove the "US only" note

## Test plan
- Search for a Finnish stock (e.g. "Mandatum" or "MANTA") and verify it appears in results
- Navigate to the ticker page and verify the TradingView chart loads correctly