### PR TITLE
Move Finnhub API key server-side

### DIFF
--- a/app/api/tickers/route.ts
+++ b/app/api/tickers/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+interface FinnhubMatch {
+  description: string
+  displaySymbol: string
+  type: string
+}
+
+export async function GET(request: NextRequest) {
+  const q = request.nextUrl.searchParams.get('q')
+  if (!q) {
+    return NextResponse.json({ error: 'Missing q parameter' }, { status: 400 })
+  }
+
+  const token = process.env.FINNHUB_API_KEY
+  if (!token) {
+    return NextResponse.json({ error: 'API key not configured' }, { status: 500 })
+  }
+
+  try {
+    const params = new URLSearchParams({ q, token })
+    const response = await fetch(`https://finnhub.io/api/v1/search?${params}`)
+
+    if (!response.ok) {
+      return NextResponse.json({ error: 'Upstream Finnhub error' }, { status: 502 })
+    }
+
+    const data = await response.json()
+
+    const results = (data.result ?? [])
+      .filter((match: FinnhubMatch) => match.type === 'Common Stock')
+      .map((match: FinnhubMatch) => ({
+        symbol: match.displaySymbol,
+        name: match.description,
+      }))
+
+    return NextResponse.json(results)
+  } catch {
+    return NextResponse.json({ error: 'Failed to fetch tickers' }, { status: 502 })
+  }
+}

--- a/app/components/CompanySearch.tsx
+++ b/app/components/CompanySearch.tsx
@@ -9,13 +9,6 @@ interface SearchResult {
   logo_url?: string
 }
 
-interface FinnhubMatch {
-  description: string
-  displaySymbol: string
-  symbol: string
-  type: string
-}
-
 interface CompanySearchProps {
   ticker: string
   onTickerChange: (ticker: string) => void
@@ -78,25 +71,13 @@ const CompanySearch: React.FC<CompanySearchProps> = ({
 
     setSearchLoading(true)
     try {
-      // TODO: move this to server side
-      const params = new URLSearchParams({
-        q: query,
-        token: process.env.NEXT_PUBLIC_FINNHUB_API_KEY ?? '',
-      })
-      const response = await fetch(`https://finnhub.io/api/v1/search?${params}`)
-      const data = await response.json()
+      const params = new URLSearchParams({ q: query })
+      const response = await fetch(`/api/tickers?${params}`)
+      if (!response.ok) throw new Error(`Search failed: ${response.status}`)
+      const results: SearchResult[] = await response.json()
 
-      if (data.result) {
-        // Filter to only Common Stock type
-        const results = data.result
-          .filter((match: FinnhubMatch) => match.type === 'Common Stock')
-          .map((match: FinnhubMatch) => ({
-            symbol: match.displaySymbol,
-            name: match.description,
-          }))
-        setSearchResults(results)
-        setShowDropdown(results.length > 0)
-      }
+      setSearchResults(results)
+      setShowDropdown(results.length > 0)
     } catch (err) {
       console.error('Failed to fetch symbols:', err)
     } finally {
@@ -166,6 +147,8 @@ const CompanySearch: React.FC<CompanySearchProps> = ({
         e.preventDefault()
         if (selectedIndex >= 0 && selectedIndex < searchResults.length) {
           handleSelectOption(searchResults[selectedIndex])
+        } else if (searchResults.length > 0) {
+          handleSelectOption(searchResults[0])
         }
         break
       case 'Escape':


### PR DESCRIPTION
## Summary
- Add `/api/tickers` Next.js API route that proxies Finnhub search server-side
- Remove `NEXT_PUBLIC_FINNHUB_API_KEY` exposure from client bundle
- Simplify `CompanySearch.tsx` — filtering now handled server-side
- Fix Enter key navigating to first result when dropdown is open

## Test plan
- [ ] Search for a non-local company name, confirm dropdown appears
- [ ] Verify `/api/tickers?q=...` in network tab (not `finnhub.io`)
- [ ] Confirm `NEXT_PUBLIC_FINNHUB` does not appear in browser bundle
- [ ] Press Enter with dropdown open (no arrow selection) — should navigate to first result
- [ ] Update Vercel env var: rename `NEXT_PUBLIC_FINNHUB_API_KEY` → `FINNHUB_API_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)