### PR TITLE
feat(chat): support structured thinking_status progress UI

### DIFF
--- a/app/components/Chat.tsx
+++ b/app/components/Chat.tsx
@@ -113,10 +113,7 @@ const ThreadView: React.FC<ThreadViewProps> = ({
       {isNormalThread(thread) && (
         <div className="mb-4">
           {/* Only show thoughts bubble in the latest thread so that bubble from previous threads do not change */}
-          <ThoughtBubble
-            thought={thread.thoughts[thread.thoughts.length - 1]}
-            isThinking={isThinking && isLastThread}
-          />
+          <ThoughtBubble thoughts={thread.thoughts} isThinking={isThinking && isLastThread} />
         </div>
       )}
       {/* Only show answer for normal threads */}

--- a/app/components/FilingChatbox.tsx
+++ b/app/components/FilingChatbox.tsx
@@ -1,7 +1,7 @@
 'use client'
 import React, { useEffect, useRef, useCallback, useMemo } from 'react'
 import { useParams } from 'next/navigation'
-import { AnalysisPhase, ThoughtStep, useChatState } from './hooks/useChatState'
+import { ThoughtStep, useChatState } from './hooks/useChatState'
 import { useChatAPI } from './hooks/useChatAPI'
 import { FileText } from 'lucide-react'
 import { ChatboxUI } from './Chat'
@@ -124,14 +124,14 @@ const FilingChatbox: React.FC<FilingChatboxProps> = ({
               const data = JSON.parse(jsonStr)
 
               if (data.type === 'thinking_status') {
+                if (!data.phase || data.step == null) continue
                 const thoughtStep: ThoughtStep = {
                   body: String(data.body || ''),
-                  phase: (data.phase as AnalysisPhase) || 'analyze',
-                  step: data.step ?? thoughts.length + 1,
-                  totalSteps: data.total_steps ?? undefined,
+                  phase: data.phase,
+                  step: data.step,
+                  totalSteps: data.total_steps,
                 }
                 thoughts = [...thoughts, thoughtStep]
-                // Update thoughts
                 updateThread(threadId, { thoughts })
               } else if (data.type === 'answer') {
                 isFetchingAnalysisRef.current = false

--- a/app/components/FilingChatbox.tsx
+++ b/app/components/FilingChatbox.tsx
@@ -1,7 +1,7 @@
 'use client'
 import React, { useEffect, useRef, useCallback, useMemo } from 'react'
 import { useParams } from 'next/navigation'
-import { useChatState } from './hooks/useChatState'
+import { AnalysisPhase, ThoughtStep, useChatState } from './hooks/useChatState'
 import { useChatAPI } from './hooks/useChatAPI'
 import { FileText } from 'lucide-react'
 import { ChatboxUI } from './Chat'
@@ -90,7 +90,7 @@ const FilingChatbox: React.FC<FilingChatboxProps> = ({
       const reader = response.body.getReader()
       const decoder = new TextDecoder()
       let buffer = ''
-      let thoughts: string[] = []
+      let thoughts: ThoughtStep[] = []
       const relatedQuestions: string[] = []
 
       while (true) {
@@ -124,7 +124,13 @@ const FilingChatbox: React.FC<FilingChatboxProps> = ({
               const data = JSON.parse(jsonStr)
 
               if (data.type === 'thinking_status') {
-                thoughts = [...thoughts, data.body]
+                const thoughtStep: ThoughtStep = {
+                  body: String(data.body || ''),
+                  phase: (data.phase as AnalysisPhase) || 'analyze',
+                  step: data.step ?? thoughts.length + 1,
+                  totalSteps: data.total_steps ?? undefined,
+                }
+                thoughts = [...thoughts, thoughtStep]
                 // Update thoughts
                 updateThread(threadId, { thoughts })
               } else if (data.type === 'answer') {

--- a/app/components/ThoughtBubble.tsx
+++ b/app/components/ThoughtBubble.tsx
@@ -1,120 +1,101 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from './Collapsible'
-import { ChevronDown, Sparkles } from 'lucide-react'
-import MarkdownContent from './MarkdownContent'
+import {
+  Brain,
+  CheckCircle2,
+  ChevronDown,
+  Database,
+  Globe,
+  ListPlus,
+  Loader2,
+  Sparkles,
+} from 'lucide-react'
+import { AnalysisPhase, ThoughtStep } from './hooks/useChatState'
+
+const phaseIcon: Record<AnalysisPhase, React.ElementType> = {
+  classify: Brain,
+  data_fetch: Database,
+  search: Globe,
+  analyze: Sparkles,
+  enrich: ListPlus,
+}
+
+function StepIcon({ phase, isActive }: { phase: AnalysisPhase; isActive: boolean }) {
+  const Icon = phaseIcon[phase] || Sparkles
+  return (
+    <Icon
+      className={`w-3.5 h-3.5 flex-shrink-0 ${
+        isActive
+          ? 'text-[var(--accent-hover)] dark:text-[var(--accent-hover-dark)]'
+          : 'text-gray-400 dark:text-gray-500'
+      }`}
+    />
+  )
+}
 
 export function ThoughtBubble({
-  thought,
+  thoughts,
   isThinking,
 }: {
-  thought: string | null
+  thoughts: ThoughtStep[]
   isThinking: boolean
 }) {
-  const [currentThought, setCurrentThought] = useState('')
   const [isOpen, setIsOpen] = useState(true)
-  const [completedThoughts, setCompletedThoughts] = useState<string[]>([])
-  const lastThoughtRef = useRef<string | null>(null)
-  const isTypingRef = useRef(false)
 
   useEffect(() => {
     setIsOpen(isThinking)
   }, [isThinking])
 
-  useEffect(() => {
-    if (!thought || thought === lastThoughtRef.current) {
-      return
-    }
+  if (thoughts.length === 0) return null
 
-    // If we're currently typing, wait for it to complete
-    if (isTypingRef.current) {
-      const checkInterval = setInterval(() => {
-        if (!isTypingRef.current) {
-          clearInterval(checkInterval)
-          startTypingThought(thought)
-        }
-      }, 100)
-      return () => clearInterval(checkInterval)
-    }
+  const lastThought = thoughts[thoughts.length - 1]
+  const totalSteps = lastThought.totalSteps
 
-    startTypingThought(thought)
-  }, [thought])
-
-  const startTypingThought = (thought: string) => {
-    isTypingRef.current = true
-    let charIndex = 0
-    setCurrentThought('')
-
-    const typeThought = () => {
-      if (!thought) return
-      if (charIndex < thought.length) {
-        setCurrentThought(thought.slice(0, charIndex + 1))
-        charIndex++
-        setTimeout(typeThought, 10)
-      } else {
-        // When done, add to completedThoughts and update lastThoughtRef
-        setCompletedThoughts((prev) => [...prev, thought])
-        lastThoughtRef.current = thought
-        setCurrentThought('')
-        isTypingRef.current = false
-      }
-    }
-    setTimeout(typeThought, 50)
-  }
+  const headerText = isThinking
+    ? totalSteps
+      ? `Thinking... step ${lastThought.step}/${totalSteps}`
+      : 'Thinking...'
+    : `Thought for ${thoughts.length} step${thoughts.length === 1 ? '' : 's'}`
 
   return (
-    <div className="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-white p-4 rounded-lg">
-      <div className="relative">
-        <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-          <CollapsibleTrigger className="flex items-center gap-2 text-[var(--accent-hover)] dark:text-[var(--accent-hover-dark)] hover:text-[var(--accent-active)] dark:hover:text-[var(--accent-active-dark)] transition-colors">
-            <div className="flex items-center gap-2">
-              <Sparkles className="w-4 h-4" />
-              <span className="text-sm">{isThinking ? 'AI is thinking...' : 'AI thoughts'}</span>
-              {isThinking && (
-                <div className="flex gap-1">
-                  <div
-                    className="w-1 h-1 bg-[var(--accent-hover)] dark:bg-[var(--accent-hover-dark)] rounded-full animate-bounce"
-                    style={{ animationDelay: '0ms' }}
-                  ></div>
-                  <div
-                    className="w-1 h-1 bg-[var(--accent-hover)] dark:bg-[var(--accent-hover-dark)] rounded-full animate-bounce"
-                    style={{ animationDelay: '150ms' }}
-                  />
-                  <div
-                    className="w-1 h-1 bg-[var(--accent-hover)] dark:bg-[var(--accent-hover-dark)] rounded-full animate-bounce"
-                    style={{ animationDelay: '300ms' }}
-                  ></div>
-                </div>
-              )}
-            </div>
-            <ChevronDown className={`w-4 h-4 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
-          </CollapsibleTrigger>
-
-          {completedThoughts && completedThoughts.length > 0 && (
-            <CollapsibleContent className="mt-3">
-              <div className="bg-white dark:bg-gray-800 rounded-lg p-3">
-                <div className="space-y-2">
-                  {completedThoughts.map((t, index) => (
-                    <div
-                      key={index}
-                      className="text-sm text-gray-600 dark:text-gray-300 opacity-75"
-                    >
-                      <MarkdownContent content={t} smallSize />
-                    </div>
-                  ))}
-                  {currentThought && (
-                    <div className="text-sm text-[var(--accent-hover)] dark:text-[var(--accent-hover-dark)] flex items-center gap-2">
-                      <MarkdownContent content={currentThought} smallSize />
-                      <span className="w-2 h-4 bg-[var(--accent-hover)] dark:bg-[var(--accent-hover-dark)] animate-pulse"></span>
-                    </div>
-                  )}
-                </div>
-              </div>
-            </CollapsibleContent>
+    <div className="text-sm">
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <CollapsibleTrigger className="flex items-center gap-1.5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors cursor-pointer">
+          {isThinking ? (
+            <Loader2 className="w-3.5 h-3.5 animate-spin text-[var(--accent-hover)] dark:text-[var(--accent-hover-dark)]" />
+          ) : (
+            <CheckCircle2 className="w-3.5 h-3.5 text-gray-400 dark:text-gray-500" />
           )}
-        </Collapsible>
-      </div>
+          <span>{headerText}</span>
+          <ChevronDown
+            className={`w-3 h-3 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}
+          />
+        </CollapsibleTrigger>
+
+        <CollapsibleContent className="mt-2 ml-[7px] border-l border-gray-200 dark:border-gray-700 pl-3">
+          <div className="space-y-1">
+            {thoughts.map((thought, index) => {
+              const isLast = index === thoughts.length - 1
+              const isActive = isLast && isThinking
+              return (
+                <div
+                  key={index}
+                  className={`flex items-start gap-2 py-0.5 text-xs transition-opacity duration-300 ${
+                    isActive
+                      ? 'text-[var(--accent-hover)] dark:text-[var(--accent-hover-dark)]'
+                      : 'text-gray-400 dark:text-gray-500'
+                  }`}
+                >
+                  <StepIcon phase={thought.phase} isActive={isActive} />
+                  <span>{thought.body}</span>
+                </div>
+              )
+            })}
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
     </div>
   )
 }

--- a/app/components/__tests__/processStreamLine.test.ts
+++ b/app/components/__tests__/processStreamLine.test.ts
@@ -2,13 +2,12 @@ import { describe, it, expect } from 'vitest'
 import { processStreamLine, StreamState } from '../utils/processStreamLine'
 
 const SAMPLE_STREAM = `{"type": "conversation", "body": {"conversationId": "0cfacf9d-b869-4aa4-a8cf-44c6c139d418"}}
-{"type": "thinking_status", "body": "Just a moment..."}
-{"type": "thinking_status", "body": "Using Google Search to get up-to-date information. This might take a bit longer, but it will help you get a better answer."}
-{"type": "thinking_status", "body": "Analyzing question to determine required data..."}
-{"type": "thinking_status", "body": "Identifying relevant financial periods..."}
-{"type": "thinking_status", "body": "Retrieving quarterly financial data for analysis..."}
+{"type": "thinking_status", "body": "Classifying your question...", "phase": "classify", "step": 1}
+{"type": "thinking_status", "body": "Searching the web for up-to-date data...", "phase": "search", "step": 2}
+{"type": "thinking_status", "body": "Determining which financial statements to pull...", "phase": "classify", "step": 3, "total_steps": 6}
+{"type": "thinking_status", "body": "Pulling NVDA quarterly reports...", "phase": "data_fetch", "step": 4, "total_steps": 6}
 {"type": "attachment_url", "title": "Quarterly 10Q report for the quarter ending on 7/31/2025", "body": "https://www.sec.gov/Archives/edgar/data/1045810/000104581025000209/nvda-20250727.htm"}
-{"type": "thinking_status", "body": "Analyzing data and preparing insights..."}
+{"type": "thinking_status", "body": "Generating analysis...", "phase": "analyze", "step": 5, "total_steps": 6}
 {"type": "answer", "body": "N"}
 {"type": "answer", "body": "VIDIA's latest quarterly report showcases continued robust financial performance, primarily driven by exceptional"}
 {"type": "answer", "body": " growth in its Data Center segment. The company achieved record revenues and demonstrated substantial year"}
@@ -55,7 +54,19 @@ describe('processStreamLine', () => {
     expect(state.conversationId).toBe('0cfacf9d-b869-4aa4-a8cf-44c6c139d418')
     expect(state.modelName).toBe('google/gemini-2.5-flash-lite:nitro')
     expect(state.relatedQuestions).toHaveLength(3)
-    expect(state.thoughts).toHaveLength(6)
+    expect(state.thoughts).toHaveLength(5)
+    expect(state.thoughts[0]).toEqual({
+      body: 'Classifying your question...',
+      phase: 'classify',
+      step: 1,
+      totalSteps: undefined,
+    })
+    expect(state.thoughts[4]).toEqual({
+      body: 'Generating analysis...',
+      phase: 'analyze',
+      step: 5,
+      totalSteps: 6,
+    })
     expect(state.attachment).toEqual({
       title: 'Quarterly 10Q report for the quarter ending on 7/31/2025',
       url: 'https://www.sec.gov/Archives/edgar/data/1045810/000104581025000209/nvda-20250727.htm',

--- a/app/components/hooks/useChatAPI.ts
+++ b/app/components/hooks/useChatAPI.ts
@@ -1,5 +1,12 @@
 import { useRef, useState } from 'react'
-import { AnswerGround, AnswerSource, Thread, VisualBlock } from './useChatState'
+import {
+  AnalysisPhase,
+  AnswerGround,
+  AnswerSource,
+  Thread,
+  ThoughtStep,
+  VisualBlock,
+} from './useChatState'
 import { chatService } from '../services/chatService'
 
 type VisualLang = 'html' | 'svg'
@@ -9,6 +16,9 @@ type StreamChunk = {
   body?: unknown
   url?: string
   title?: string
+  phase?: string
+  step?: number
+  total_steps?: number
 }
 
 const visualMarker = (blockId: string) => `\n\n[[VISUAL_BLOCK:${blockId}]]\n\n`
@@ -62,7 +72,7 @@ export const useChatAPI = (
 
       const decoder = new TextDecoder()
       let accumulatedContent = ''
-      let thoughts: string[] = []
+      let thoughts: ThoughtStep[] = []
       let relatedQuestions: string[] = []
       let grounds: AnswerGround[] = []
       let visualBlocks: VisualBlock[] = []
@@ -206,7 +216,13 @@ export const useChatAPI = (
           if (!isThinkingRef.current) {
             isThinkingRef.current = true
           }
-          thoughts = [...thoughts, String(parsedChunk.body || '')]
+          const thoughtStep: ThoughtStep = {
+            body: String(parsedChunk.body || ''),
+            phase: (parsedChunk.phase as AnalysisPhase) || 'analyze',
+            step: parsedChunk.step ?? thoughts.length + 1,
+            totalSteps: parsedChunk.total_steps ?? undefined,
+          }
+          thoughts = [...thoughts, thoughtStep]
           updateThread(threadId, { thoughts })
           return
         }

--- a/app/components/hooks/useChatAPI.ts
+++ b/app/components/hooks/useChatAPI.ts
@@ -16,7 +16,7 @@ type StreamChunk = {
   body?: unknown
   url?: string
   title?: string
-  phase?: string
+  phase?: AnalysisPhase
   step?: number
   total_steps?: number
 }
@@ -213,14 +213,15 @@ export const useChatAPI = (
         }
 
         if (parsedChunk.type === 'thinking_status') {
+          if (!parsedChunk.phase || parsedChunk.step == null) return
           if (!isThinkingRef.current) {
             isThinkingRef.current = true
           }
           const thoughtStep: ThoughtStep = {
             body: String(parsedChunk.body || ''),
-            phase: (parsedChunk.phase as AnalysisPhase) || 'analyze',
-            step: parsedChunk.step ?? thoughts.length + 1,
-            totalSteps: parsedChunk.total_steps ?? undefined,
+            phase: parsedChunk.phase,
+            step: parsedChunk.step,
+            totalSteps: parsedChunk.total_steps,
           }
           thoughts = [...thoughts, thoughtStep]
           updateThread(threadId, { thoughts })

--- a/app/components/hooks/useChatState.ts
+++ b/app/components/hooks/useChatState.ts
@@ -24,6 +24,15 @@ export interface Attachment {
   url: string
 }
 
+export type AnalysisPhase = 'classify' | 'data_fetch' | 'search' | 'analyze' | 'enrich'
+
+export interface ThoughtStep {
+  body: string
+  phase: AnalysisPhase
+  step: number
+  totalSteps?: number
+}
+
 export interface FaqThread {
   id: string
   question: string
@@ -33,7 +42,7 @@ export interface FaqThread {
 export interface NormalThread {
   id: string
   question: string
-  thoughts: string[]
+  thoughts: ThoughtStep[]
   answer: string | null
   relatedQuestions: string[]
   grounds: AnswerGround[]

--- a/app/components/utils/processStreamLine.ts
+++ b/app/components/utils/processStreamLine.ts
@@ -3,9 +3,11 @@
  * Returns updates to apply to the accumulated state.
  */
 
+import { AnalysisPhase, ThoughtStep } from '../hooks/useChatState'
+
 export interface StreamState {
   accumulatedContent: string
-  thoughts: string[]
+  thoughts: ThoughtStep[]
   relatedQuestions: string[]
   conversationId: string | null
   modelName: string | undefined
@@ -13,7 +15,15 @@ export interface StreamState {
 }
 
 export function processStreamLine(
-  parsed: { type: string; body?: unknown; url?: string; title?: string },
+  parsed: {
+    type: string
+    body?: unknown
+    url?: string
+    title?: string
+    phase?: string
+    step?: number
+    total_steps?: number
+  },
   state: StreamState,
 ): StreamState {
   const next = { ...state }
@@ -27,16 +37,24 @@ export function processStreamLine(
     case 'answer':
       next.accumulatedContent += parsed.body as string
       break
-    case 'thinking_status':
-      next.thoughts = [...state.thoughts, parsed.body as string]
+    case 'thinking_status': {
+      const thoughtStep: ThoughtStep = {
+        body: String(parsed.body || ''),
+        phase: (parsed.phase as AnalysisPhase) || 'analyze',
+        step: parsed.step ?? state.thoughts.length + 1,
+        totalSteps: parsed.total_steps ?? undefined,
+      }
+      next.thoughts = [...state.thoughts, thoughtStep]
       break
+    }
     case 'related_question':
       next.relatedQuestions = [...state.relatedQuestions, parsed.body as string]
       break
     case 'sources': {
       if (Array.isArray(parsed.body)) {
         const links = parsed.body
-          .map((s: { name: string; url?: string }) => (s.url ? `[${s.name}](${s.url})` : s.name))
+          .filter((s: { name: string; url?: string }) => Boolean(s.url))
+          .map((s: { name: string; url?: string }) => `[${s.name}](${s.url})`)
           .join(' ')
         if (links) {
           next.accumulatedContent += links + '\n'

--- a/app/components/utils/processStreamLine.ts
+++ b/app/components/utils/processStreamLine.ts
@@ -20,7 +20,7 @@ export function processStreamLine(
     body?: unknown
     url?: string
     title?: string
-    phase?: string
+    phase?: AnalysisPhase
     step?: number
     total_steps?: number
   },
@@ -38,11 +38,12 @@ export function processStreamLine(
       next.accumulatedContent += parsed.body as string
       break
     case 'thinking_status': {
+      if (!parsed.phase || parsed.step == null) break
       const thoughtStep: ThoughtStep = {
         body: String(parsed.body || ''),
-        phase: (parsed.phase as AnalysisPhase) || 'analyze',
-        step: parsed.step ?? state.thoughts.length + 1,
-        totalSteps: parsed.total_steps ?? undefined,
+        phase: parsed.phase,
+        step: parsed.step,
+        totalSteps: parsed.total_steps,
       }
       next.thoughts = [...state.thoughts, thoughtStep]
       break


### PR DESCRIPTION
## Summary
- align frontend stream parsing with backend `thinking_status` metadata (`phase`, `step`, `total_steps`) from [stonkie_backend#13](https://github.com/vinhlee95/stonkie_backend/pull/13)
- model thread thoughts as structured `ThoughtStep` objects and propagate through shared chat hooks + filing chat flow
- redesign `ThoughtBubble` to render phase-aware step timeline and update parser behavior to keep `sources` output URL-only (matching test expectations)

## Test plan
- [x] `npm run type-check`
- [x] `npm run test:unit -- app/components/__tests__/processStreamLine.test.ts`

Made with [Cursor](https://cursor.com)