### PR TITLE
feat(home): sector nav scroll spy, scroll-to-top button

### DIFF
--- a/app/components/MostViewedCompanies.tsx
+++ b/app/components/MostViewedCompanies.tsx
@@ -62,6 +62,7 @@ export default function MostViewedCompanies({ companies }: { companies: Company[
   const sectionElementsRef = useRef<Record<string, HTMLElement | null>>({})
   const ignoreScrollSpyRef = useRef(false)
   const scrollSpyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const visibleSectionsRef = useRef<Set<string>>(new Set())
 
   const groups = useMemo(() => groupCompaniesBySector(companies), [companies])
 
@@ -116,27 +117,39 @@ export default function MostViewedCompanies({ companies }: { companies: Company[
       (entries) => {
         if (ignoreScrollSpyRef.current) return
 
-        const candidates = entries
-          .filter((e) => e.isIntersecting && e.target instanceof HTMLElement)
-          .map((e) => {
-            const el = e.target as HTMLElement
-            const key = el.dataset.sectorKey
-            if (!key) return null
-            const top = e.boundingClientRect.top
-            return { key, top, ratio: e.intersectionRatio }
-          })
-          .filter((x): x is { key: string; top: number; ratio: number } => x !== null)
+        // Update the set of currently visible sections
+        for (const e of entries) {
+          const key = (e.target as HTMLElement).dataset?.sectorKey
+          if (!key) continue
+          if (e.isIntersecting) {
+            visibleSectionsRef.current.add(key)
+          } else {
+            visibleSectionsRef.current.delete(key)
+          }
+        }
 
-        if (candidates.length === 0) {
+        if (visibleSectionsRef.current.size === 0) {
           setActiveKey(ALL_SECTORS_KEY)
           return
         }
+
+        // Pick the visible section closest to the sticky nav
+        const candidates = [...visibleSectionsRef.current]
+          .map((key) => {
+            const el = sectionElementsRef.current[key]
+            if (!el) return null
+            const top = el.getBoundingClientRect().top
+            return { key, top }
+          })
+          .filter((x): x is { key: string; top: number } => x !== null)
+
+        if (candidates.length === 0) return
 
         candidates.sort((a, b) => {
           const da = Math.abs(a.top - 88)
           const db = Math.abs(b.top - 88)
           if (da !== db) return da - db
-          return b.ratio - a.ratio
+          return 0
         })
 
         setActiveKey(candidates[0]!.key)

--- a/app/components/MostViewedCompanies.tsx
+++ b/app/components/MostViewedCompanies.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import CompanyList, { Company } from '@/app/CompanyList'
+import { Company } from '@/app/CompanyList'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import ScrollToTopButton from './ScrollToTopButton'
 import SectorFilter, { SectorNavItem } from './SectorFilter'
+import SectorSection from './SectorSection'
 
 /** Sentinel for "scroll to top / all sectors" */
 export const ALL_SECTORS_KEY = 'all'
@@ -193,7 +194,7 @@ export default function MostViewedCompanies({ companies }: { companies: Company[
             >
               {group.label}
             </h2>
-            <CompanyList companies={group.companies} />
+            <SectorSection companies={group.companies} />
           </section>
         ))}
       </div>

--- a/app/components/MostViewedCompanies.tsx
+++ b/app/components/MostViewedCompanies.tsx
@@ -127,7 +127,10 @@ export default function MostViewedCompanies({ companies }: { companies: Company[
           })
           .filter((x): x is { key: string; top: number; ratio: number } => x !== null)
 
-        if (candidates.length === 0) return
+        if (candidates.length === 0) {
+          setActiveKey(ALL_SECTORS_KEY)
+          return
+        }
 
         candidates.sort((a, b) => {
           const da = Math.abs(a.top - 88)

--- a/app/components/MostViewedCompanies.tsx
+++ b/app/components/MostViewedCompanies.tsx
@@ -1,30 +1,186 @@
 'use client'
-import { useState } from 'react'
+
 import CompanyList, { Company } from '@/app/CompanyList'
-import SectorFilter from './SectorFilter'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import ScrollToTopButton from './ScrollToTopButton'
+import SectorFilter, { SectorNavItem } from './SectorFilter'
+
+/** Sentinel for "scroll to top / all sectors" */
+export const ALL_SECTORS_KEY = 'all'
+
+export function normalizeSectorKey(sector: string): string {
+  return sector.trim().toLowerCase()
+}
+
+export type SectorGroup = {
+  key: string
+  label: string
+  companies: Company[]
+}
+
+/** Stable DOM id for anchor links / scroll targets */
+export function sectorDomId(key: string): string {
+  return `sector-${key.replace(/\s+/g, '-')}`
+}
+
+const OTHER_KEY = 'other'
+
+export function groupCompaniesBySector(companies: Company[]): SectorGroup[] {
+  const map = new Map<string, { label: string; companies: Company[] }>()
+  const order: string[] = []
+
+  for (const company of companies) {
+    const raw = company.sector?.trim()
+    const key = raw ? normalizeSectorKey(raw) : OTHER_KEY
+    const label = raw || 'Other'
+
+    if (!map.has(key)) {
+      map.set(key, { label, companies: [] })
+      order.push(key)
+    }
+    map.get(key)!.companies.push(company)
+  }
+
+  const groups = order.map((key) => {
+    const entry = map.get(key)!
+    return { key, label: entry.label, companies: entry.companies }
+  })
+
+  groups.sort((a, b) => {
+    const diff = b.companies.length - a.companies.length
+    if (diff !== 0) return diff
+    return order.indexOf(a.key) - order.indexOf(b.key)
+  })
+
+  return groups
+}
+
+const SCROLL_SPY_ROOT_MARGIN = '-88px 0px -50% 0px'
 
 export default function MostViewedCompanies({ companies }: { companies: Company[] }) {
-  const [selectedSector, setSelectedSector] = useState<string>('All Sectors')
+  const topRef = useRef<HTMLDivElement>(null)
+  const sectionElementsRef = useRef<Record<string, HTMLElement | null>>({})
+  const ignoreScrollSpyRef = useRef(false)
+  const scrollSpyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // Extract unique sectors
-  const sectors = [
-    'All Sectors',
-    ...Array.from(new Set(companies.map((c) => c.sector).filter(Boolean))),
-  ]
+  const groups = useMemo(() => groupCompaniesBySector(companies), [companies])
 
-  // Filter companies based on selected sector
-  const filteredCompanies =
-    selectedSector === 'All Sectors'
-      ? companies
-      : companies.filter((c) => c.sector === selectedSector)
+  const navItems: SectorNavItem[] = useMemo(
+    () => [
+      { key: ALL_SECTORS_KEY, label: 'All Sectors' },
+      ...groups.map((g) => ({ key: g.key, label: g.label })),
+    ],
+    [groups],
+  )
+
+  const [activeKey, setActiveKey] = useState<string>(ALL_SECTORS_KEY)
+
+  const setSectionRef = useCallback((key: string) => {
+    return (el: HTMLElement | null) => {
+      sectionElementsRef.current[key] = el
+    }
+  }, [])
+
+  const navigateToSector = useCallback((key: string) => {
+    if (scrollSpyTimeoutRef.current) {
+      clearTimeout(scrollSpyTimeoutRef.current)
+    }
+    ignoreScrollSpyRef.current = true
+    setActiveKey(key)
+
+    if (key === ALL_SECTORS_KEY) {
+      topRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    } else {
+      const el = document.getElementById(sectorDomId(key))
+      el?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+
+    scrollSpyTimeoutRef.current = setTimeout(() => {
+      ignoreScrollSpyRef.current = false
+      scrollSpyTimeoutRef.current = null
+    }, 800)
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (scrollSpyTimeoutRef.current) {
+        clearTimeout(scrollSpyTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (groups.length === 0) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (ignoreScrollSpyRef.current) return
+
+        const candidates = entries
+          .filter((e) => e.isIntersecting && e.target instanceof HTMLElement)
+          .map((e) => {
+            const el = e.target as HTMLElement
+            const key = el.dataset.sectorKey
+            if (!key) return null
+            const top = e.boundingClientRect.top
+            return { key, top, ratio: e.intersectionRatio }
+          })
+          .filter((x): x is { key: string; top: number; ratio: number } => x !== null)
+
+        if (candidates.length === 0) return
+
+        candidates.sort((a, b) => {
+          const da = Math.abs(a.top - 88)
+          const db = Math.abs(b.top - 88)
+          if (da !== db) return da - db
+          return b.ratio - a.ratio
+        })
+
+        setActiveKey(candidates[0]!.key)
+      },
+      {
+        root: null,
+        rootMargin: SCROLL_SPY_ROOT_MARGIN,
+        threshold: [0, 0.05, 0.1, 0.2, 0.35, 0.5, 0.75, 1],
+      },
+    )
+
+    for (const g of groups) {
+      const el = sectionElementsRef.current[g.key]
+      if (el) observer.observe(el)
+    }
+
+    return () => observer.disconnect()
+  }, [groups])
 
   return (
-    <CompanyList companies={filteredCompanies}>
-      <SectorFilter
-        sectors={sectors}
-        selectedSector={selectedSector}
-        onSelectSector={setSelectedSector}
-      />
-    </CompanyList>
+    <div ref={topRef} id="most-viewed-companies-top" className="scroll-mt-0">
+      <h1 className="text-2xl font-bold mb-6">Most Viewed Companies</h1>
+
+      <SectorFilter items={navItems} activeKey={activeKey} onNavigate={navigateToSector} />
+
+      <ScrollToTopButton onScrollToTop={() => navigateToSector(ALL_SECTORS_KEY)} />
+
+      <div className="space-y-10">
+        {groups.map((group) => (
+          <section
+            key={group.key}
+            id={sectorDomId(group.key)}
+            ref={setSectionRef(group.key)}
+            data-sector-key={group.key}
+            className="scroll-mt-24"
+            aria-labelledby={`heading-${sectorDomId(group.key)}`}
+          >
+            <h2
+              id={`heading-${sectorDomId(group.key)}`}
+              className="text-lg font-semibold text-gray-800 dark:text-white mb-4"
+            >
+              {group.label}
+            </h2>
+            <CompanyList companies={group.companies} />
+          </section>
+        ))}
+      </div>
+    </div>
   )
 }

--- a/app/components/ScrollToTopButton.tsx
+++ b/app/components/ScrollToTopButton.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+interface ScrollToTopButtonProps {
+  onScrollToTop: () => void
+}
+
+export default function ScrollToTopButton({ onScrollToTop }: ScrollToTopButtonProps) {
+  const [visible, setVisible] = useState(false)
+  const lastScrollY = useRef(0)
+  const hasScrolledDown = useRef(false)
+
+  useEffect(() => {
+    let ticking = false
+
+    const onScroll = () => {
+      if (ticking) return
+      ticking = true
+      requestAnimationFrame(() => {
+        const currentY = window.scrollY
+        const scrollingUp = currentY < lastScrollY.current
+        const pastThreshold = currentY > 300
+
+        if (!pastThreshold) {
+          // Near top — hide button and reset
+          setVisible(false)
+          hasScrolledDown.current = false
+        } else if (!scrollingUp) {
+          // Scrolling down past threshold — mark that user has scrolled down, hide
+          hasScrolledDown.current = true
+          setVisible(false)
+        } else if (scrollingUp && hasScrolledDown.current) {
+          // Scrolling up after having scrolled down — show
+          setVisible(true)
+        }
+
+        lastScrollY.current = currentY
+        ticking = false
+      })
+    }
+
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  const handleClick = useCallback(() => {
+    setVisible(false)
+    hasScrolledDown.current = false
+    onScrollToTop()
+  }, [onScrollToTop])
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label="Scroll to top of company list"
+      title="Back to top"
+      className={`fixed bottom-6 right-6 z-50 flex items-center justify-center w-12 h-12 rounded-full bg-[var(--accent-active)] text-white shadow-lg hover:brightness-110 active:scale-95 transition-all duration-300 cursor-pointer ${
+        visible
+          ? 'opacity-100 translate-y-0 pointer-events-auto'
+          : 'opacity-0 translate-y-4 pointer-events-none'
+      }`}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        className="w-6 h-6"
+        aria-hidden="true"
+      >
+        <path
+          fillRule="evenodd"
+          d="M10 17a.75.75 0 0 1-.75-.75V5.612L5.29 9.77a.75.75 0 0 1-1.08-1.04l5.25-5.5a.75.75 0 0 1 1.08 0l5.25 5.5a.75.75 0 1 1-1.08 1.04l-3.96-4.158V16.25A.75.75 0 0 1 10 17Z"
+          clipRule="evenodd"
+        />
+      </svg>
+    </button>
+  )
+}

--- a/app/components/SectorFilter.tsx
+++ b/app/components/SectorFilter.tsx
@@ -1,40 +1,65 @@
 'use client'
 
+import { useCallback, useEffect, useRef } from 'react'
+
+export type SectorNavItem = { key: string; label: string }
+
 export interface SectorFilterProps {
-  sectors: string[]
-  selectedSector: string
-  onSelectSector: (sector: string) => void
+  items: SectorNavItem[]
+  activeKey: string
+  onNavigate: (key: string) => void
 }
 
-export default function SectorFilter({
-  sectors,
-  selectedSector,
-  onSelectSector,
-}: SectorFilterProps) {
+export default function SectorFilter({ items, activeKey, onNavigate }: SectorFilterProps) {
+  const buttonRefs = useRef<Record<string, HTMLButtonElement | null>>({})
+
+  const setButtonRef = useCallback(
+    (key: string) => (el: HTMLButtonElement | null) => {
+      buttonRefs.current[key] = el
+    },
+    [],
+  )
+
+  useEffect(() => {
+    const el = buttonRefs.current[activeKey]
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' })
+    }
+  }, [activeKey])
+
   return (
-    <div className="mb-6 -mx-4 px-4 sm:mx-0 sm:px-0">
-      <div className="flex gap-2 overflow-x-auto sm:flex-wrap pb-2 sm:pb-0">
-        {sectors.map((sector) => (
-          <button
-            key={sector}
-            onClick={() => onSelectSector(sector)}
-            style={
-              selectedSector === sector
-                ? {
-                    backgroundColor: 'var(--accent-active)',
-                    color: 'white',
-                  }
-                : undefined
-            }
-            className={`px-4 py-2 rounded-full text-sm font-medium transition-colors whitespace-nowrap flex-shrink-0 cursor-pointer ${
-              selectedSector === sector
-                ? 'dark:bg-[var(--accent-active-dark)]'
-                : 'bg-gray-200 text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
-            }`}
-          >
-            {sector}
-          </button>
-        ))}
+    <div
+      className="sticky top-0 z-20 -mx-4 px-4 sm:mx-0 sm:px-0 mb-6 border-b border-gray-200/80 dark:border-gray-700/80 bg-[var(--background)] py-3"
+      role="navigation"
+      aria-label="Sector sections"
+    >
+      <div className="flex gap-2 overflow-x-auto sm:flex-wrap pb-1 sm:pb-0">
+        {items.map((item) => {
+          const selected = activeKey === item.key
+          return (
+            <button
+              key={item.key}
+              ref={setButtonRef(item.key)}
+              type="button"
+              onClick={() => onNavigate(item.key)}
+              style={
+                selected
+                  ? {
+                      backgroundColor: 'var(--accent-active)',
+                      color: 'white',
+                    }
+                  : undefined
+              }
+              className={`px-4 py-2 rounded-full text-sm font-medium transition-colors whitespace-nowrap flex-shrink-0 cursor-pointer ${
+                selected
+                  ? 'dark:bg-[var(--accent-active-dark)]'
+                  : 'bg-gray-200 text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
+              }`}
+            >
+              {item.label}
+            </button>
+          )
+        })}
       </div>
     </div>
   )

--- a/app/components/SectorSection.tsx
+++ b/app/components/SectorSection.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import CompanyList, { Company } from '@/app/CompanyList'
+
+const MOBILE_LIMIT = 5
+
+interface SectorSectionProps {
+  companies: Company[]
+}
+
+export default function SectorSection({ companies }: SectorSectionProps) {
+  const sectionRef = useRef<HTMLDivElement>(null)
+  const [expanded, setExpanded] = useState(false)
+  const hasMore = companies.length > MOBILE_LIMIT
+  const visibleCompanies = expanded ? companies : companies.slice(0, MOBILE_LIMIT)
+
+  return (
+    <div ref={sectionRef}>
+      {/* Mobile: show limited list with expand/collapse */}
+      <div className="sm:hidden">
+        <div className="relative">
+          <CompanyList companies={visibleCompanies} />
+          {hasMore && !expanded && (
+            <div className="absolute bottom-0 left-0 right-0 h-32 bg-gradient-to-t from-[var(--background)] to-transparent pointer-events-none" />
+          )}
+        </div>
+        {hasMore && (
+          <button
+            type="button"
+            onClick={() => {
+              if (expanded) {
+                // Collapsing — scroll to last visible card after state update
+                requestAnimationFrame(() => {
+                  const grid = sectionRef.current?.querySelector('.grid')
+                  const lastCard = grid?.children[MOBILE_LIMIT - 1] as HTMLElement | undefined
+                  lastCard?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                })
+              }
+              setExpanded((prev) => !prev)
+            }}
+            className="w-full mt-2 py-3 text-sm font-medium text-[var(--accent-active)] hover:underline cursor-pointer"
+          >
+            {expanded ? 'Show less' : `Show all ${companies.length} companies`}
+          </button>
+        )}
+      </div>
+
+      {/* Desktop: show all */}
+      <div className="hidden sm:block">
+        <CompanyList companies={companies} />
+      </div>
+    </div>
+  )
+}

--- a/app/components/__tests__/MostViewedCompanies.test.tsx
+++ b/app/components/__tests__/MostViewedCompanies.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import MostViewedCompanies, {
+  groupCompaniesBySector,
+  normalizeSectorKey,
+} from '../MostViewedCompanies'
+import { Company } from '@/app/CompanyList'
+
+function tickerLinks() {
+  return screen
+    .getAllByRole('link')
+    .filter((el) => el.getAttribute('href')?.startsWith('/tickers/'))
+}
+
+describe('MostViewedCompanies sector grouping', () => {
+  it('normalizes sector key case-insensitively', () => {
+    expect(normalizeSectorKey('Technology')).toBe('technology')
+    expect(normalizeSectorKey('TECHNOLOGY')).toBe('technology')
+    expect(normalizeSectorKey('  Health Care  ')).toBe('health care')
+  })
+
+  it('merges companies with same sector under different casing', () => {
+    const companies: Company[] = [
+      {
+        name: 'A',
+        ticker: 'AAA',
+        logo_url: '',
+        sector: 'Technology',
+      },
+      {
+        name: 'B',
+        ticker: 'BBB',
+        logo_url: '',
+        sector: 'TECHNOLOGY',
+      },
+    ]
+    const groups = groupCompaniesBySector(companies)
+    expect(groups).toHaveLength(1)
+    expect(groups[0].key).toBe('technology')
+    expect(groups[0].label).toBe('Technology')
+    expect(groups[0].companies).toHaveLength(2)
+  })
+
+  it('orders sectors by ticker count descending', () => {
+    const companies: Company[] = [
+      { name: 'F', ticker: 'F1', logo_url: '', sector: 'Financials' },
+      { name: 'T1', ticker: 'T1', logo_url: '', sector: 'Technology' },
+      { name: 'T2', ticker: 'T2', logo_url: '', sector: 'Technology' },
+      { name: 'T3', ticker: 'T3', logo_url: '', sector: 'Technology' },
+    ]
+    const groups = groupCompaniesBySector(companies)
+    expect(groups.map((g) => g.key)).toEqual(['technology', 'financials'])
+  })
+
+  it('renders one section per sector with all companies visible', () => {
+    const companies: Company[] = [
+      { name: 'A', ticker: 'AAA', logo_url: '', sector: 'Technology' },
+      { name: 'B', ticker: 'BBB', logo_url: '', sector: 'Financials' },
+      { name: 'C', ticker: 'CCC', logo_url: '', sector: 'Technology' },
+    ]
+    render(<MostViewedCompanies companies={companies} />)
+
+    expect(screen.getByRole('heading', { name: 'Technology' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Financials' })).toBeInTheDocument()
+    expect(tickerLinks()).toHaveLength(3)
+  })
+})

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,7 +46,6 @@ export default async function Page() {
         <MarketChart />
       </div>
       <FavouritesList />
-      <h1 className="text-2xl font-bold mb-6">Most Viewed Companies</h1>
       {data && <MostViewedCompanies companies={data} />}
       <h1 className="text-2xl font-bold mb-6 mt-8">ETFs</h1>
       {etfData && etfData.length > 0 && <MostViewedETFs etfs={etfData} />}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -46,3 +46,16 @@ const localStorageMock = {
   key: vi.fn(),
 }
 global.localStorage = localStorageMock as Storage
+
+// jsdom has no IntersectionObserver (used by MostViewedCompanies scroll-spy)
+class IntersectionObserverMock implements IntersectionObserver {
+  root: Element | Document | null = null
+  rootMargin = ''
+  thresholds: ReadonlyArray<number> = []
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+  takeRecords = vi.fn((): IntersectionObserverEntry[] => [])
+  constructor(_callback: IntersectionObserverCallback, _options?: IntersectionObserverInit) {}
+}
+global.IntersectionObserver = IntersectionObserverMock as unknown as typeof IntersectionObserver


### PR DESCRIPTION
## Summary
- Group companies by sector with sticky filter bar and IntersectionObserver-based scroll spy
- Add scroll-to-top FAB (arrow-up icon) that appears on scroll-up, same behavior as "All Sectors" filter
- Auto-scroll active filter chip into view on mobile horizontal overflow
- Move "Most Viewed Companies" heading into the component
- Add IntersectionObserver mock for test setup

## Test plan
- [ ] Scroll through sectors on mobile — active chip scrolls into view in the filter bar
- [ ] Scroll down then scroll up slightly — scroll-to-top button appears
- [ ] Click scroll-to-top button — scrolls to top of company list
- [ ] Verify button has proper accessibility (aria-label, title tooltip)
- [ ] Test on desktop — button and chip behavior works across viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)