### PR TITLE
feat(market-recap): add dig deeper chat modal

### DIFF
--- a/.claude/plans/recap-dig-deeper.md
+++ b/.claude/plans/recap-dig-deeper.md
@@ -1,0 +1,70 @@
+# Dig Deeper — v1 (button + initial chat modal state)
+
+## Context
+
+The market recap card ([MarketRecapCard.tsx](app/components/MarketRecapCard.tsx)) currently has no entry point to chat. Commit `a6635e8` removed an earlier non-interactive "ask about this market" CTA because the backend wasn't ready. The design handoff (`recap-chat.html` + chats 1–3) specifies a "Dig deeper" CTA at the bottom-right of the _expanded_ recap that opens a chat modal grounded in the recap.
+
+**Scope of v1**: ship just the **button** and the **initial state of the chat modal**. No related-question fetching, no asking/answering wiring, no new backend endpoints. The recap data is already in hand from `MarketRecapIsland` — pass it through the modal, no re-fetch.
+
+## What lands in v1
+
+1. **"Dig deeper" pill button** on the expanded `MarketRecapCard`, bottom-right of the bullets section. Pulses (port `pulse-ring` keyframes from `recap-chat.html:81-95`). Mirrors the prototype: rounded-full accent bg, sparkle icon + label + arrow icon.
+2. **`RecapChatModal`** — opens on click. Mobile = full-screen sheet; desktop = right-side panel (reuse the existing responsive layout from `ChatboxUI` / `InsightChatModal`). Slide-in animation matching prototype keyframes (`chat-anim` / `chat-sheet-anim`).
+3. **Initial state inside the modal**:
+   - Top: compact recap context chip ("Digging deeper into · {Market} {Cadence} · {date}" + the recap's `summary` clamped to 2 lines). Always visible, non-sticky, non-dismissible.
+   - Header: "Dig deeper into this recap".
+   - Helper line: "Ask about this recap…" (or similar).
+   - Input pinned to bottom, **disabled** with placeholder "Coming soon — backend in progress" (or similar). No submit handler wired, no suggestions list.
+   - Close button (top-right) returns to the recap.
+4. **State reset on close** so reopen shows the initial state.
+
+Out of v1: suggested questions list (no fetch, no client derivation), submit/stream wiring, conversationId persistence, per-bullet "Ask" chips, sticky/dismissible context variants.
+
+## Files
+
+### New
+
+- `app/components/RecapChatModal.tsx` — owns `isOpen`, `isDesktop` (window-width listener at 768px, mirroring [InsightChatModal.tsx:35-44](app/tickers/[ticker]/insights/InsightChatModal.tsx:35)), `useScrollLock`. Receives `recap: MarketRecapItem` plus `market` + `cadence` (for the header chip). Renders the close chrome + scrollable body (recap context chip + header + helper text) + disabled input. Self-contained — does **not** mount `ChatProvider`/`ChatboxUI` yet (they bring full chat state we don't need; introduce in v2).
+- `app/components/__tests__/RecapChatModal.test.tsx` — renders with a fixture recap; asserts header copy, summary present, input disabled, close button works.
+
+### Modified
+
+- `app/components/MarketRecapCard.tsx`
+  - New optional prop `onDigDeeper?: () => void`.
+  - When `expanded === true` and `onDigDeeper` defined, render the pill button bottom-right of the bullets section.
+- `app/components/MarketRecapIsland.tsx`
+  - Wrap the rendered `<MarketRecapCard>` with local `isOpen` state and a sibling `<RecapChatModal recap={activeRecap} ... open={isOpen} onClose={...}/>`.
+  - `activeRecap` = whichever cadence is currently displayed; pass `daily ?? weekly` (matches the card's fallback in [MarketRecapCard.tsx:43](app/components/MarketRecapCard.tsx:43)).
+  - `onDigDeeper={() => setIsOpen(true)}`.
+- `app/globals.css`
+  - Add `pulse-ring`, `chat-anim`, `chat-sheet-anim` keyframes ported from `recap-chat.html`.
+- `app/components/__tests__/MarketRecapCard.test.tsx`
+  - Add: button visible only when expanded + `onDigDeeper` provided, click fires the handler.
+
+## Reused — do not re-implement
+
+- `useScrollLock` ([app/components/hooks/useScrollLock.ts](app/components/hooks/useScrollLock.ts)) — locks page scroll while modal is open.
+- Tailwind tokens (`--accent-active`, `--button-background`, `--accent-light`) already defined in the project.
+- `lucide-react` icons (`Sparkles`, `ArrowRight`, `X`) — already used elsewhere (no new icon library).
+
+## Verification
+
+1. `npm run type-check && npm run test:unit` — green, including new tests.
+2. `npm run dev` against backend on 8080. Open `/`.
+3. Expand the recap → "Dig deeper" pill appears bottom-right and pulses. Collapsed state hides it.
+4. Click → modal opens. Resize across 768px and reopen to confirm desktop side-panel vs mobile full-screen-sheet.
+5. Modal shows: recap context chip (correct date + summary text matching the card), "Dig deeper into this recap" header, disabled input.
+6. Close → recap card visible again; reopen → initial state again (no leftover state).
+7. Add a Playwright spec asserting the pill is visible after expanding the recap and the modal opens on click. (`npm run e2e`)
+
+## v2 (next slice, not now)
+
+- Suggested-questions list — backend adds `suggested_questions` to `MarketRecapItem` on the existing `/api/markets/{market}/recaps` response (no new fetch).
+- Asking/answering — new chat endpoint `POST /api/v2/recaps/{recap_id}/analyze` mirroring `/api/v2/companies/{ticker}/analyze`; frontend adds `chatService.analyzeRecapQuestion`, hoists v1's modal into `ChatboxUI` with a `RecapChatbox` wrapping `useChatState` + `useChatAPI` (mode: 'recap'). Per-recap `conversationId` persistence.
+
+## Decisions confirmed with user
+
+- No recap re-fetch in the modal — reuse the data already loaded by `MarketRecapIsland`.
+- v1 ships button + modal initial state only; no related questions, no chat wiring.
+- Context card style: always visible, non-sticky.
+- Backend will be planned in parallel; frontend should not block on it.

--- a/app/components/MarketRecapCard.tsx
+++ b/app/components/MarketRecapCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { CalendarDays, Clock3, Sparkles } from 'lucide-react'
+import { ArrowRight, CalendarDays, Clock3, Sparkles } from 'lucide-react'
 import { MarketRecapItem } from '@/lib/api/marketRecap'
 import SourceChip from './SourceChip'
 
@@ -10,6 +10,7 @@ type Cadence = 'daily' | 'weekly'
 interface MarketRecapCardProps {
   daily: MarketRecapItem | null
   weekly: MarketRecapItem | null
+  onDigDeeper?: () => void
 }
 
 function bulletColor(index: number): string {
@@ -35,7 +36,7 @@ function formatRecapPeriod(periodStart: string, periodEnd: string): string {
   return `${fmt.format(start)} – ${fmt.format(end)}`
 }
 
-export default function MarketRecapCard({ daily, weekly }: MarketRecapCardProps) {
+export default function MarketRecapCard({ daily, weekly, onDigDeeper }: MarketRecapCardProps) {
   const initialCadence: Cadence = daily ? 'daily' : 'weekly'
   const [cadence, setCadence] = useState<Cadence>(initialCadence)
   const [expanded, setExpanded] = useState(false)
@@ -216,6 +217,23 @@ export default function MarketRecapCard({ daily, weekly }: MarketRecapCardProps)
               </div>
             ))}
           </div>
+
+          {onDigDeeper && (
+            <div className="mt-4 flex items-center justify-end">
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onDigDeeper()
+                }}
+                className="pulse-ring inline-flex items-center gap-2 rounded-full bg-[var(--accent-active)] dark:bg-[var(--accent-active-dark)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-[var(--accent-hover)] dark:hover:bg-[var(--accent-hover-dark)] cursor-pointer"
+              >
+                <Sparkles size={15} strokeWidth={2.4} />
+                Dig deeper
+                <ArrowRight size={14} strokeWidth={2.5} />
+              </button>
+            </div>
+          )}
         </div>
       )}
     </section>

--- a/app/components/MarketRecapIsland.tsx
+++ b/app/components/MarketRecapIsland.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import MarketRecapCard from './MarketRecapCard'
 import MarketRecapCardPlaceholder from './MarketRecapCardPlaceholder'
+import RecapChatModal from './RecapChatModal'
 import MarketRecapUnavailable, {
   type MarketRecapUnavailablePeriod,
   type MarketRecapUnavailableVariant,
@@ -25,6 +26,7 @@ function MarketRecapIslandInner({ marketKey, unavailablePeriod, onRetryRequest }
   const [pair, setPair] = useState<MarketRecapPair | null>(null)
   const [pending, setPending] = useState(true)
   const [unavailable, setUnavailable] = useState<Unavailable>(null)
+  const [chatOpen, setChatOpen] = useState(false)
 
   useEffect(() => {
     const backendMarket = toBackendMarketCode(marketKey)
@@ -82,7 +84,26 @@ function MarketRecapIslandInner({ marketKey, unavailablePeriod, onRetryRequest }
     )
   }
   if (!pair?.daily && !pair?.weekly) return null
-  return <MarketRecapCard daily={pair.daily} weekly={pair.weekly} />
+  const activeRecap = pair.daily ?? pair.weekly
+  const activeCadence = pair.daily ? 'daily' : 'weekly'
+  return (
+    <>
+      <MarketRecapCard
+        daily={pair.daily}
+        weekly={pair.weekly}
+        onDigDeeper={() => setChatOpen(true)}
+      />
+      {activeRecap && (
+        <RecapChatModal
+          open={chatOpen}
+          onClose={() => setChatOpen(false)}
+          recap={activeRecap}
+          market={marketKey}
+          cadence={activeCadence}
+        />
+      )}
+    </>
+  )
 }
 
 export default function MarketRecapIsland({

--- a/app/components/RecapChatModal.tsx
+++ b/app/components/RecapChatModal.tsx
@@ -1,12 +1,11 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Sparkles } from 'lucide-react'
 import { ChatboxUI } from './Chat'
 import { useChatState } from './hooks/useChatState'
-import { useChatAPI, type AnalyzeFn } from './hooks/useChatAPI'
+import { useRecapChatAPI } from './hooks/useRecapChatAPI'
 import { useScrollLock } from './hooks/useScrollLock'
-import { chatService } from './services/chatService'
 import type { MarketRecapItem } from '@/lib/api/marketRecap'
 
 interface RecapChatModalProps {
@@ -98,8 +97,8 @@ export default function RecapChatModal({
   const questionsSeededRef = useRef<string | null>(null)
 
   useEffect(() => {
-    const questions = recap.questions
-    if (!questions || questions.length === 0) return
+    const questions = recap.questions ?? []
+    if (questions.length === 0) return
     if (questionsSeededRef.current === recapId) return
 
     const threadId = `recap-questions-${recapId}`
@@ -116,26 +115,12 @@ export default function RecapChatModal({
     questionsSeededRef.current = recapId
   }, [recap.questions, recapId, updateThread, threads])
 
-  const analyzeFn: AnalyzeFn = useCallback(
-    (question, _useUrlContext, deepAnalysis, preferredModel, conversationId, signal) =>
-      chatService.analyzeRecapQuestion(
-        recapId,
-        question,
-        conversationId,
-        deepAnalysis,
-        preferredModel,
-        signal,
-      ),
-    [recapId],
-  )
-
-  const { handleSubmit, isLoading, isThinking, cancelRequest } = useChatAPI(
-    undefined,
+  const { handleSubmit, isLoading, isThinking, cancelRequest } = useRecapChatAPI(
+    recapId,
     updateThread,
     conversationId,
     setConversationId,
     recordActivity,
-    analyzeFn,
   )
 
   const handleFAQClick = async (question: string) => {

--- a/app/components/RecapChatModal.tsx
+++ b/app/components/RecapChatModal.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Sparkles } from 'lucide-react'
+import { ChatboxUI } from './Chat'
+import { useChatState } from './hooks/useChatState'
+import { useChatAPI, type AnalyzeFn } from './hooks/useChatAPI'
+import { useScrollLock } from './hooks/useScrollLock'
+import { chatService } from './services/chatService'
+import type { MarketRecapItem } from '@/lib/api/marketRecap'
+
+interface RecapChatModalProps {
+  open: boolean
+  onClose: () => void
+  recap: MarketRecapItem
+  market: string
+  cadence: string
+}
+
+function formatPeriodShort(periodStart: string, periodEnd: string): string {
+  const fmt = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' })
+  const start = new Date(`${periodStart}T00:00:00Z`)
+  const end = new Date(`${periodEnd}T00:00:00Z`)
+  if (Number.isNaN(start.getTime())) return periodStart
+  if (periodStart === periodEnd || Number.isNaN(end.getTime())) return fmt.format(start)
+  return `${fmt.format(start)} – ${fmt.format(end)}`
+}
+
+function RecapContextCard({
+  recap,
+  market,
+  cadence,
+}: {
+  recap: MarketRecapItem
+  market: string
+  cadence: string
+}) {
+  const period = formatPeriodShort(recap.period_start, recap.period_end)
+  const cadenceLabel = cadence === 'daily' ? 'Daily' : 'Weekly'
+
+  return (
+    <div className="mb-4 rounded-xl border border-[rgba(40,105,86,0.13)] dark:border-[rgba(156,214,194,0.25)] bg-[var(--accent-light)] dark:bg-[var(--accent-light-dark)] p-3 flex items-start gap-3">
+      <span className="mt-0.5 inline-flex h-7 w-7 items-center justify-center rounded-full bg-white dark:bg-gray-800 text-[var(--accent-active)] dark:text-[var(--accent-active-dark)] shadow-sm shrink-0">
+        <Sparkles size={13} strokeWidth={2.4} />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-[10px] font-extrabold uppercase tracking-[0.12em] text-[var(--accent-active)] dark:text-[var(--accent-active-dark)]">
+            Digging deeper into
+          </span>
+          <span className="text-[11px] font-semibold text-gray-700 dark:text-gray-200">
+            {market} {cadenceLabel} Recap · {period}
+          </span>
+        </div>
+        <p className="mt-0.5 text-base leading-6 text-gray-700 dark:text-gray-200">
+          {recap.summary}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export default function RecapChatModal({
+  open,
+  onClose,
+  recap,
+  market,
+  cadence,
+}: RecapChatModalProps) {
+  const [isDesktop, setIsDesktop] = useState(false)
+  useScrollLock({ isLocked: open, isDesktop })
+
+  useEffect(() => {
+    const check = () => setIsDesktop(window.innerWidth >= 768)
+    check()
+    window.addEventListener('resize', check)
+    return () => window.removeEventListener('resize', check)
+  }, [])
+
+  const recapId = String(recap.id)
+  const recapScope = `recap:${recapId}`
+
+  const {
+    threads,
+    input,
+    setInput,
+    addThread,
+    updateThread,
+    deepAnalysis,
+    setDeepAnalysis,
+    preferredModel,
+    setPreferredModel,
+    conversationId,
+    setConversationId,
+    recordActivity,
+  } = useChatState(recapScope)
+
+  const questionsSeededRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    const questions = recap.questions
+    if (!questions || questions.length === 0) return
+    if (questionsSeededRef.current === recapId) return
+
+    const threadId = `recap-questions-${recapId}`
+    const existing = threads.find((t) => t.question === 'Dig deeper into this recap')
+    if (!existing) {
+      updateThread(threadId, {
+        id: threadId,
+        question: 'Dig deeper into this recap',
+        relatedQuestions: questions,
+      })
+    } else if (existing.relatedQuestions.length !== questions.length) {
+      updateThread(existing.id, { relatedQuestions: questions })
+    }
+    questionsSeededRef.current = recapId
+  }, [recap.questions, recapId, updateThread, threads])
+
+  const analyzeFn: AnalyzeFn = useCallback(
+    (question, _useUrlContext, deepAnalysis, preferredModel, conversationId, signal) =>
+      chatService.analyzeRecapQuestion(
+        recapId,
+        question,
+        conversationId,
+        deepAnalysis,
+        preferredModel,
+        signal,
+      ),
+    [recapId],
+  )
+
+  const { handleSubmit, isLoading, isThinking, cancelRequest } = useChatAPI(
+    undefined,
+    updateThread,
+    conversationId,
+    setConversationId,
+    recordActivity,
+    analyzeFn,
+  )
+
+  const handleFAQClick = async (question: string) => {
+    const threadId = addThread(question)
+    await handleSubmit(question, threadId, false, deepAnalysis, preferredModel)
+  }
+
+  if (!open) return null
+
+  return (
+    <ChatboxUI
+      threads={threads}
+      input={input}
+      setInput={setInput}
+      addThread={addThread}
+      handleSubmit={(question: string, threadId: string) =>
+        handleSubmit(question, threadId, false, deepAnalysis, preferredModel)
+      }
+      isLoading={isLoading}
+      isThinking={isThinking}
+      cancelRequest={cancelRequest}
+      onClose={onClose}
+      isDesktop={isDesktop}
+      handleFAQClick={handleFAQClick}
+      deepAnalysis={deepAnalysis}
+      setDeepAnalysis={setDeepAnalysis}
+      preferredModel={preferredModel}
+      setPreferredModel={setPreferredModel}
+    >
+      <RecapContextCard recap={recap} market={market} cadence={cadence} />
+    </ChatboxUI>
+  )
+}

--- a/app/components/__tests__/MarketRecapCard.test.tsx
+++ b/app/components/__tests__/MarketRecapCard.test.tsx
@@ -36,6 +36,7 @@ const weeklyRecap: MarketRecapItem = {
       fetched_at: '2026-04-25T12:10:00Z',
     },
   ],
+  questions: [],
 }
 
 const dailyRecap: MarketRecapItem = {
@@ -55,6 +56,7 @@ const dailyRecap: MarketRecapItem = {
       fetched_at: '2026-04-24T21:00:00Z',
     },
   ],
+  questions: [],
 }
 
 describe('MarketRecapCard', () => {

--- a/app/components/__tests__/MarketRecapCard.test.tsx
+++ b/app/components/__tests__/MarketRecapCard.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, within } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import MarketRecapCard from '../MarketRecapCard'
 import { MarketRecapItem } from '@/lib/api/marketRecap'
 
@@ -8,6 +8,7 @@ function escapeRegExp(value: string): string {
 }
 
 const weeklyRecap: MarketRecapItem = {
+  id: 1,
   period_start: '2026-04-20',
   period_end: '2026-04-24',
   created_at: '2026-04-25T13:18:03.721444Z',
@@ -38,6 +39,7 @@ const weeklyRecap: MarketRecapItem = {
 }
 
 const dailyRecap: MarketRecapItem = {
+  id: 2,
   period_start: '2026-04-24',
   period_end: '2026-04-24',
   created_at: '2026-04-25T01:30:00.000000Z',
@@ -309,6 +311,36 @@ describe('MarketRecapCard', () => {
         new Date('2026-04-20T00:00:00Z'),
       )
       expect(weeklyLabel.textContent ?? '').toContain(start)
+    })
+  })
+
+  describe('Dig deeper button', () => {
+    it('is hidden when collapsed or onDigDeeper is not provided', () => {
+      render(<MarketRecapCard daily={null} weekly={weeklyRecap} />)
+      expect(screen.queryByRole('button', { name: /dig deeper/i })).not.toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: /market recap/i }))
+      expect(screen.queryByRole('button', { name: /dig deeper/i })).not.toBeInTheDocument()
+    })
+
+    it('appears in expanded state when onDigDeeper is provided', () => {
+      const handler = vi.fn()
+      render(<MarketRecapCard daily={null} weekly={weeklyRecap} onDigDeeper={handler} />)
+
+      expect(screen.queryByRole('button', { name: /dig deeper/i })).not.toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: /market recap/i }))
+      const digBtn = screen.getByRole('button', { name: /dig deeper/i })
+      expect(digBtn).toBeInTheDocument()
+    })
+
+    it('fires onDigDeeper on click', () => {
+      const handler = vi.fn()
+      render(<MarketRecapCard daily={null} weekly={weeklyRecap} onDigDeeper={handler} />)
+
+      fireEvent.click(screen.getByRole('button', { name: /market recap/i }))
+      fireEvent.click(screen.getByRole('button', { name: /dig deeper/i }))
+      expect(handler).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/app/components/__tests__/RecapChatModal.test.tsx
+++ b/app/components/__tests__/RecapChatModal.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import RecapChatModal from '../RecapChatModal'
+import { MarketRecapItem } from '@/lib/api/marketRecap'
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+const recap: MarketRecapItem = {
+  id: 91,
+  period_start: '2026-05-08',
+  period_end: '2026-05-08',
+  created_at: '2026-05-09T07:00:00Z',
+  summary: 'U.S. stocks finished higher on Friday, with the S&P 500 reaching record territory.',
+  bullets: [{ text: 'S&P 500 climbed 0.84%', citations: [{ source_id: 's1' }] }],
+  sources: [
+    {
+      id: 's1',
+      url: 'https://example.com/1',
+      title: 'Source',
+      publisher: 'Reuters',
+      published_at: '2026-05-08T20:00:00Z',
+      fetched_at: '2026-05-08T21:00:00Z',
+    },
+  ],
+  questions: [
+    'How will reduced Fed rate cut expectations impact markets?',
+    "What caused HubSpot's plunge?",
+  ],
+}
+
+describe('RecapChatModal', () => {
+  it('renders nothing when closed', () => {
+    const { container } = render(
+      <RecapChatModal open={false} onClose={vi.fn()} recap={recap} market="USA" cadence="daily" />,
+    )
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('shows recap context card when open', () => {
+    render(
+      <RecapChatModal open={true} onClose={vi.fn()} recap={recap} market="USA" cadence="daily" />,
+    )
+    expect(screen.getByText(/Digging deeper into/i)).toBeInTheDocument()
+    expect(screen.getByText(/U\.S\. stocks finished higher/i)).toBeInTheDocument()
+    expect(screen.getByText(/USA Daily Recap/i)).toBeInTheDocument()
+  })
+
+  it('renders a functional text input', () => {
+    render(
+      <RecapChatModal open={true} onClose={vi.fn()} recap={recap} market="USA" cadence="daily" />,
+    )
+    const textarea = screen.getByRole('textbox')
+    expect(textarea).not.toBeDisabled()
+  })
+
+  it('seeds suggested questions from recap.questions', () => {
+    render(
+      <RecapChatModal open={true} onClose={vi.fn()} recap={recap} market="USA" cadence="daily" />,
+    )
+    expect(screen.getByText('Dig deeper into this recap')).toBeInTheDocument()
+    expect(screen.getByText(/How will reduced Fed rate cut/i)).toBeInTheDocument()
+    expect(screen.getByText(/What caused HubSpot/i)).toBeInTheDocument()
+  })
+
+  it('calls onClose when close button is clicked', () => {
+    const onClose = vi.fn()
+    render(
+      <RecapChatModal open={true} onClose={onClose} recap={recap} market="USA" cadence="daily" />,
+    )
+    fireEvent.click(screen.getByLabelText('Close'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/components/hooks/useChatAPI.ts
+++ b/app/components/hooks/useChatAPI.ts
@@ -32,12 +32,22 @@ type V2SourceChunk = {
 
 const visualMarker = (blockId: string) => `\n\n[[VISUAL_BLOCK:${blockId}]]\n\n`
 
+export type AnalyzeFn = (
+  question: string,
+  useUrlContext: boolean,
+  deepAnalysis: boolean,
+  preferredModel: string,
+  conversationId: string | null,
+  signal: AbortSignal,
+) => Promise<ReadableStreamDefaultReader<Uint8Array> | undefined>
+
 export const useChatAPI = (
   ticker: string | undefined,
   updateThread: (threadId: string, updates: Partial<Thread>) => void,
   conversationId: string | null = null,
   setConversationId: (id: string | null) => void = () => {},
   recordActivity: () => void = () => {},
+  analyzeFn?: AnalyzeFn,
 ) => {
   const [isLoading, setIsLoading] = useState(false)
   const isThinkingRef = useRef(false)
@@ -68,15 +78,24 @@ export const useChatAPI = (
     // Record activity when a question is asked
     recordActivity()
     try {
-      const reader = await chatService.analyzeQuestion(
-        question,
-        ticker,
-        useUrlContext,
-        deepAnalysis,
-        preferredModel,
-        conversationId,
-        signal,
-      )
+      const reader = analyzeFn
+        ? await analyzeFn(
+            question,
+            useUrlContext,
+            deepAnalysis,
+            preferredModel,
+            conversationId,
+            signal,
+          )
+        : await chatService.analyzeQuestion(
+            question,
+            ticker,
+            useUrlContext,
+            deepAnalysis,
+            preferredModel,
+            conversationId,
+            signal,
+          )
       if (!reader) throw new Error('Failed to get reader')
 
       const decoder = new TextDecoder()

--- a/app/components/hooks/useRecapChatAPI.ts
+++ b/app/components/hooks/useRecapChatAPI.ts
@@ -32,8 +32,8 @@ type V2SourceChunk = {
 
 const visualMarker = (blockId: string) => `\n\n[[VISUAL_BLOCK:${blockId}]]\n\n`
 
-export const useChatAPI = (
-  ticker: string | undefined,
+export const useRecapChatAPI = (
+  recapId: string,
   updateThread: (threadId: string, updates: Partial<Thread>) => void,
   conversationId: string | null = null,
   setConversationId: (id: string | null) => void = () => {},
@@ -55,26 +55,23 @@ export const useChatAPI = (
   const handleSubmit = async (
     question: string,
     threadId: string,
-    useUrlContext: boolean = false,
+    _useUrlContext: boolean = false,
     deepAnalysis: boolean = false,
     preferredModel: string = 'fastest',
   ) => {
-    // Create new AbortController for this request
     abortControllerRef.current = new AbortController()
     const signal = abortControllerRef.current.signal
 
     setIsLoading(true)
     isThinkingRef.current = true
-    // Record activity when a question is asked
     recordActivity()
     try {
-      const reader = await chatService.analyzeQuestion(
+      const reader = await chatService.analyzeRecapQuestion(
+        recapId,
         question,
-        ticker,
-        useUrlContext,
+        conversationId,
         deepAnalysis,
         preferredModel,
-        conversationId,
         signal,
       )
       if (!reader) throw new Error('Failed to get reader')
@@ -120,12 +117,10 @@ export const useChatAPI = (
 
       const handleParsedChunk = (parsedChunk: StreamChunk) => {
         if (parsedChunk.type === 'conversation') {
-          // Handle conversation event - store conversationId
           const body = (parsedChunk.body || {}) as { conversationId?: string }
           const newConversationId = body.conversationId || null
           if (newConversationId) {
             setConversationId(newConversationId)
-            // Record activity when conversation is established
             recordActivity()
           }
           return
@@ -315,7 +310,6 @@ export const useChatAPI = (
 
         buffer += decoder.decode(value, { stream: true })
         const lines = buffer.split('\n')
-        // Keep the last element as it may be incomplete
         buffer = lines.pop() || ''
 
         for (const line of lines) {
@@ -330,7 +324,6 @@ export const useChatAPI = (
         }
       }
 
-      // Process any remaining buffer
       if (buffer.trim()) {
         try {
           const parsedChunk = JSON.parse(buffer.trim()) as StreamChunk

--- a/app/components/services/chatService.ts
+++ b/app/components/services/chatService.ts
@@ -42,6 +42,37 @@ export const chatService = {
     return response.body?.getReader()
   },
 
+  async analyzeRecapQuestion(
+    recapId: string,
+    question: string,
+    conversationId: string | null = null,
+    deepAnalysis: boolean = false,
+    preferredModel: string = 'fastest',
+    signal?: AbortSignal,
+  ) {
+    const response = await fetch(
+      `${BACKEND_URL}/api/recaps/${encodeURIComponent(recapId)}/analyze`,
+      {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          question,
+          conversationId,
+          deepAnalysis,
+          preferredModel,
+        }),
+        signal,
+      },
+    )
+
+    if (!response.ok) {
+      throw new Error('Failed to get analysis')
+    }
+
+    return response.body?.getReader()
+  },
+
   async fetchDetailedReport(ticker: string | undefined, slug: string) {
     const response = await fetch(`${BACKEND_URL}/api/companies/${ticker}/reports/${slug}`)
     return response.body?.getReader()

--- a/app/globals.css
+++ b/app/globals.css
@@ -239,3 +239,73 @@ body.safari-scroll-lock .modal-content {
     background: rgba(255, 255, 255, 0.12);
   }
 }
+
+/* Dig-deeper CTA pulse */
+@keyframes pulse-ring {
+  0% {
+    box-shadow: 0 0 0 0 rgba(4, 78, 57, 0.45);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(4, 78, 57, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(4, 78, 57, 0);
+  }
+}
+
+.pulse-ring {
+  animation: pulse-ring 1.8s cubic-bezier(0.66, 0, 0, 1) infinite;
+}
+
+@media (prefers-color-scheme: dark) {
+  @keyframes pulse-ring {
+    0% {
+      box-shadow: 0 0 0 0 rgba(66, 162, 135, 0.45);
+    }
+    70% {
+      box-shadow: 0 0 0 10px rgba(66, 162, 135, 0);
+    }
+    100% {
+      box-shadow: 0 0 0 0 rgba(66, 162, 135, 0);
+    }
+  }
+}
+
+/* Recap chat modal slide-in */
+@keyframes recap-chat-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.recap-chat-anim {
+  animation: recap-chat-slide-in 220ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+@keyframes recap-chat-sheet-in {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+.recap-chat-sheet-anim {
+  animation: recap-chat-sheet-in 280ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pulse-ring {
+    animation: none;
+  }
+  .recap-chat-anim,
+  .recap-chat-sheet-anim {
+    animation: none;
+  }
+}

--- a/lib/api/marketRecap.ts
+++ b/lib/api/marketRecap.ts
@@ -25,7 +25,7 @@ export type MarketRecapItem = {
   summary: string
   bullets: RecapBullet[]
   sources: RecapSource[]
-  questions?: string[]
+  questions: string[]
 }
 
 export type MarketRecapResponse = {

--- a/lib/api/marketRecap.ts
+++ b/lib/api/marketRecap.ts
@@ -18,12 +18,14 @@ export type RecapSource = {
 }
 
 export type MarketRecapItem = {
+  id: number
   period_start: string
   period_end: string
   created_at: string
   summary: string
   bullets: RecapBullet[]
   sources: RecapSource[]
+  questions?: string[]
 }
 
 export type MarketRecapResponse = {


### PR DESCRIPTION
## Summary

- Add "Dig deeper" pulsing CTA button on expanded market recap card
- Opens a chat modal (reuses `ChatboxUI`) seeded with backend-supplied recap questions
- Wires `POST /api/recaps/:recapId/analyze` for recap-grounded Q&A via `chatService.analyzeRecapQuestion`
- Extends `useChatAPI` with optional `analyzeFn` param for custom analyze calls (backward-compatible)
- Adds `id` + `questions` fields to `MarketRecapItem` type to match updated backend payload

## Test plan

- [ ] Expand recap card → "Dig deeper" button visible, pulses
- [ ] Click button → chat modal opens with recap context card + 3 suggested questions
- [ ] Click a suggested question → streams answer from recap analyze endpoint
- [ ] Type free-form question → same streaming flow
- [ ] Close modal → reopen shows initial state
- [ ] `npm run type-check && npm run test:unit` passes (137 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)