### PR TITLE
feat(favourites): daily recap on home favourite cards

### DIFF
--- a/app/components/FavouriteCard.tsx
+++ b/app/components/FavouriteCard.tsx
@@ -8,6 +8,7 @@ import { ETFListItem } from '@/app/components/ETFList'
 import { useFavourites } from './hooks/useFavourites'
 import TradingViewMiniChart from './TradingViewMiniChart'
 import { toTradingViewSymbol, isRestricted } from '@/app/lib/tradingview'
+import type { TickerRecapItem } from '@/lib/api/tickerRecap'
 
 type FavouriteItem = Company | ETFListItem
 
@@ -104,11 +105,101 @@ function CompactCardBody({ item }: { item: FavouriteItem }) {
   )
 }
 
+type RecapMode = 'daily' | 'weekly'
+
+/** Formats an ISO timestamp to a bare "HH:MM" 24h clock (e.g. "07:01"). Null when unparseable. */
+function formatRecapTime(iso: string | null): string | null {
+  if (!iso) return null
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return null
+  return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false })
+}
+
+/**
+ * Compact Daily / Weekly segmented switch inside a recap caption. Card-level state.
+ * Buttons stop propagation so tapping them never triggers the card's Link navigation.
+ */
+function RecapModeSwitch({
+  mode,
+  onChange,
+}: {
+  mode: RecapMode
+  onChange: (m: RecapMode) => void
+}) {
+  const opts: { k: RecapMode; label: string; title: string }[] = [
+    { k: 'daily', label: 'D', title: 'Daily recap' },
+    { k: 'weekly', label: 'W', title: 'Weekly recap' },
+  ]
+  return (
+    <div className="inline-flex gap-0.5 p-0.5 rounded-full bg-gray-100 dark:bg-gray-700">
+      {opts.map((o) => {
+        const on = mode === o.k
+        return (
+          <button
+            key={o.k}
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              onChange(o.k)
+            }}
+            className={`w-6 h-5 rounded-full text-[11px] font-bold transition-colors cursor-pointer ${
+              on
+                ? 'bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 shadow-sm'
+                : 'bg-transparent text-gray-400 dark:text-gray-500'
+            }`}
+            aria-pressed={on}
+            aria-label={o.title}
+            title={o.title}
+          >
+            {o.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+/**
+ * Inline recap caption under a card's chart: a "✦ Recap · {time}" label, a Daily/Weekly
+ * mode switch, and the recap summary. Weekly has no precomputed data yet, so its tab shows
+ * a placeholder until the backend supplies weekly recaps.
+ */
+function RecapCaption({ recap }: { recap: TickerRecapItem }) {
+  const [mode, setMode] = useState<RecapMode>('daily')
+  const time = formatRecapTime(recap.created_at)
+  return (
+    <div className="pt-3 pb-1 mt-1 border-t border-gray-100 dark:border-gray-700">
+      <div className="flex items-center gap-2 mb-2">
+        <span className="inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-[0.12em] text-gray-400 dark:text-gray-500">
+          <span className="text-amber-500 dark:text-amber-400">✦</span>Recap
+        </span>
+        {mode === 'daily' && time && (
+          <span className="text-[11px] font-medium text-gray-400 dark:text-gray-500">· {time}</span>
+        )}
+        <div className="ml-auto">
+          <RecapModeSwitch mode={mode} onChange={setMode} />
+        </div>
+      </div>
+      {mode === 'daily' ? (
+        <p className="m-0 text-sm leading-relaxed text-gray-600 dark:text-gray-300">
+          {recap.summary}
+        </p>
+      ) : (
+        <p className="m-0 text-sm italic leading-relaxed text-gray-400 dark:text-gray-500">
+          Weekly recap coming soon.
+        </p>
+      )}
+    </div>
+  )
+}
+
 export interface FavouriteCardProps {
   item: FavouriteItem
   variant?: 'grid' | 'rail'
   earningsInDays?: number
   headline?: string
+  /** Latest precomputed daily recap for this ticker. Renders a caption under the chart when present. */
+  recap?: TickerRecapItem | null
 }
 
 export default function FavouriteCard({
@@ -116,6 +207,7 @@ export default function FavouriteCard({
   variant = 'grid',
   earningsInDays,
   headline,
+  recap,
 }: FavouriteCardProps) {
   const hasEarnings = earningsInDays != null && earningsInDays <= 60
   const hasNews = !!headline
@@ -124,7 +216,8 @@ export default function FavouriteCard({
 
   const showChart = !isRestricted(toTradingViewSymbol(item.ticker))
   const chartHeight = variant === 'rail' ? 120 : 140
-  const cardHeight = showChart ? (variant === 'rail' ? 160 : 180) : undefined
+  // Fixed height only when the card has no recap caption; with a recap it grows to fit the text.
+  const cardHeight = showChart && !recap ? (variant === 'rail' ? 160 : 180) : undefined
 
   return (
     <article
@@ -175,6 +268,8 @@ export default function FavouriteCard({
             )}
           </div>
         )}
+
+        {recap && <RecapCaption recap={recap} />}
       </Link>
     </article>
   )

--- a/app/components/FavouritesList.tsx
+++ b/app/components/FavouritesList.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useFavourites } from './hooks/useFavourites'
+import { useTickerRecaps } from './hooks/useTickerRecaps'
 import { Company } from '@/app/CompanyList'
 import { ETFListItem } from '@/app/components/ETFList'
 import FavouriteCard from './FavouriteCard'
@@ -41,6 +42,9 @@ export default function FavouritesList() {
   const { favourites: etfs, isInitialized: eInit } =
     useFavourites<ETFListItem>('stonkie_favourites_etf')
 
+  // Precomputed daily recaps, keyed by uppercase ticker. ETFs have no recaps.
+  const recaps = useTickerRecaps(companies.map((c) => c.ticker))
+
   if (!cInit || !eInit) return <FavouritesSkeleton />
   if (companies.length === 0 && etfs.length === 0) return null
 
@@ -72,16 +76,26 @@ export default function FavouritesList() {
       </div>
 
       {/* Desktop: grid */}
-      <div className="hidden md:grid grid-cols-2 md:grid-cols-3 gap-3.5">
+      <div className="hidden md:grid grid-cols-2 md:grid-cols-3 items-start gap-3.5">
         {items.map((it) => (
-          <FavouriteCard key={it.ticker} item={it} variant="grid" />
+          <FavouriteCard
+            key={it.ticker}
+            item={it}
+            variant="grid"
+            recap={recaps[it.ticker.toUpperCase()]}
+          />
         ))}
       </div>
 
       {/* Mobile: horizontal scroll-snap rail */}
-      <div className="md:hidden flex gap-3 overflow-x-auto snap-x snap-mandatory no-scrollbar -mx-2 px-2 pb-1">
+      <div className="md:hidden flex items-start gap-3 overflow-x-auto snap-x snap-mandatory no-scrollbar -mx-2 px-2 pb-1">
         {items.map((it) => (
-          <FavouriteCard key={it.ticker} item={it} variant="rail" />
+          <FavouriteCard
+            key={it.ticker}
+            item={it}
+            variant="rail"
+            recap={recaps[it.ticker.toUpperCase()]}
+          />
         ))}
       </div>
     </section>

--- a/app/components/__tests__/FavouriteCard.test.tsx
+++ b/app/components/__tests__/FavouriteCard.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@/tests/test-utils'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect } from 'vitest'
+import FavouriteCard from '../FavouriteCard'
+import type { Company } from '@/app/CompanyList'
+import type { TickerRecapItem } from '@/lib/api/tickerRecap'
+
+const company: Company = {
+  name: 'NVIDIA Corporation',
+  ticker: 'NVDA',
+  logo_url: 'https://example.com/nvda.png',
+  sector: 'Technology',
+  country: 'USA',
+  exchange: 'NASDAQ',
+}
+
+const recap: TickerRecapItem = {
+  id: 1,
+  period_start: '2026-07-03',
+  period_end: '2026-07-03',
+  created_at: '2026-07-04T07:01:00Z',
+  summary: 'NVIDIA slipped 1.4% as traders trimmed AI exposure ahead of supplier updates.',
+  bullets: [],
+  sources: [],
+  price_change: null,
+}
+
+describe('FavouriteCard recap caption', () => {
+  it('renders the daily recap summary when a recap is provided', () => {
+    render(<FavouriteCard item={company} recap={recap} />)
+    expect(screen.getByText(/NVIDIA slipped 1.4%/i)).toBeInTheDocument()
+    expect(screen.getByText('Recap')).toBeInTheDocument()
+  })
+
+  it('does not render a recap caption when no recap is provided', () => {
+    render(<FavouriteCard item={company} />)
+    expect(screen.queryByText('Recap')).not.toBeInTheDocument()
+  })
+
+  it('shows a placeholder on the weekly tab and restores the daily summary', async () => {
+    const user = userEvent.setup()
+    render(<FavouriteCard item={company} recap={recap} />)
+
+    await user.click(screen.getByRole('button', { name: /weekly recap/i }))
+    expect(screen.getByText(/weekly recap coming soon/i)).toBeInTheDocument()
+    expect(screen.queryByText(/NVIDIA slipped 1.4%/i)).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /daily recap/i }))
+    expect(screen.getByText(/NVIDIA slipped 1.4%/i)).toBeInTheDocument()
+  })
+})

--- a/app/components/__tests__/HomePageFavourites.test.tsx
+++ b/app/components/__tests__/HomePageFavourites.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@/tests/test-utils'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, beforeEach } from 'vitest'
 import MostViewedCompanies from '../MostViewedCompanies'

--- a/app/components/__tests__/MostViewedCompanies.test.tsx
+++ b/app/components/__tests__/MostViewedCompanies.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@/tests/test-utils'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import MostViewedCompanies, {
   groupCompaniesBySector,


### PR DESCRIPTION
Renders each favourite's precomputed daily recap under its card chart on the home page, per the Claude Design spec.

- `✦ Recap · {time}` caption + summary, wired via the existing `useTickerRecaps` hook
- Per-card **D/W** switch; weekly shows a placeholder until the backend wires `cadence=weekly`
- Shown only when a recap exists; `items-start` on the grid/rail so cards don't stretch
- New `FavouriteCard.test.tsx`; existing home tests moved to the RQ-provider render

🤖 Generated with [Claude Code](https://claude.com/claude-code)