### PR TITLE
feat(ticker-recap): render daily/weekly recap card on ticker detail page

### DIFF
--- a/app/api/companies/[ticker]/recaps/route.ts
+++ b/app/api/companies/[ticker]/recaps/route.ts
@@ -8,8 +8,10 @@ const BACKEND_URL =
 /** Allowed tickers: 1-10 alphanumerics, optional dot/dash segment (e.g. BRK.B). */
 const TICKER_RE = /^[A-Z0-9]{1,10}([.-][A-Z0-9]{1,4})?$/
 
+const CADENCES = ['daily', 'weekly'] as const
+
 export async function GET(
-  _req: NextRequest,
+  req: NextRequest,
   context: { params: Promise<{ ticker: string }> },
 ): Promise<NextResponse> {
   const ticker = (await context.params).ticker.toUpperCase()
@@ -18,7 +20,13 @@ export async function GET(
     return NextResponse.json({ error: 'invalid ticker' }, { status: 400 })
   }
 
-  const url = `${BACKEND_URL}/api/companies/${ticker}/recaps?cadence=daily&limit=1`
+  // Default to daily so existing watchlist callers (no param) keep working.
+  const requested = req.nextUrl.searchParams.get('cadence')
+  const cadence = (CADENCES as readonly string[]).includes(requested ?? '')
+    ? (requested as string)
+    : 'daily'
+
+  const url = `${BACKEND_URL}/api/companies/${ticker}/recaps?cadence=${cadence}&limit=1`
   const response = await fetch(url, { cache: 'no-store' })
   if (!response.ok) {
     return NextResponse.json(null, {

--- a/app/components/TickerRecapCard.tsx
+++ b/app/components/TickerRecapCard.tsx
@@ -1,0 +1,230 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { CalendarDays, Clock3, Sparkles } from 'lucide-react'
+import type { TickerRecapItem, TickerRecapCadence } from '@/lib/api/tickerRecap'
+import SourceChip from './SourceChip'
+
+interface TickerRecapCardProps {
+  symbol: string
+  daily: TickerRecapItem | null
+  weekly: TickerRecapItem | null
+}
+
+function bulletColor(index: number): string {
+  const palette = ['bg-blue-600', 'bg-amber-600', 'bg-rose-600', 'bg-emerald-700']
+  return palette[index % palette.length]!
+}
+
+function formatRecapCreatedAt(createdAt: string | null): string {
+  if (!createdAt) return ''
+  const date = new Date(createdAt)
+  if (Number.isNaN(date.getTime())) return createdAt
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date)
+}
+
+function formatRecapPeriod(periodStart: string, periodEnd: string): string {
+  const fmt = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' })
+  const start = new Date(`${periodStart}T00:00:00Z`)
+  const end = new Date(`${periodEnd}T00:00:00Z`)
+  if (Number.isNaN(start.getTime())) return periodStart
+  if (periodStart === periodEnd || Number.isNaN(end.getTime())) return fmt.format(start)
+  return `${fmt.format(start)} – ${fmt.format(end)}`
+}
+
+export default function TickerRecapCard({ symbol, daily, weekly }: TickerRecapCardProps) {
+  const initialCadence: TickerRecapCadence = daily ? 'daily' : 'weekly'
+  const [cadence, setCadence] = useState<TickerRecapCadence>(initialCadence)
+  const [expanded, setExpanded] = useState(true)
+
+  const recap = cadence === 'daily' ? (daily ?? weekly) : (weekly ?? daily)
+  const showCadenceToggle = Boolean(daily && weekly)
+
+  const cadenceTabRefs = useRef<(HTMLSpanElement | null)[]>([])
+  const [cadenceIndicator, setCadenceIndicator] = useState({ left: 0, width: 0 })
+  useEffect(() => {
+    if (!showCadenceToggle) return
+    const activeIndex = cadence === 'daily' ? 0 : 1
+    const el = cadenceTabRefs.current[activeIndex]
+    if (el) setCadenceIndicator({ left: el.offsetLeft, width: el.offsetWidth })
+  }, [cadence, showCadenceToggle])
+
+  const formattedCreatedAt = useMemo(
+    () => (recap ? formatRecapCreatedAt(recap.created_at) : ''),
+    [recap],
+  )
+  const formattedPeriod = useMemo(
+    () => (recap ? formatRecapPeriod(recap.period_start, recap.period_end) : ''),
+    [recap],
+  )
+  const sourceById = useMemo(() => {
+    return new Map((recap?.sources ?? []).map((source) => [source.id, source]))
+  }, [recap])
+
+  if (!recap) return null
+
+  return (
+    <section
+      aria-label={`${symbol} recap`}
+      className="rounded-2xl border border-[rgba(40,105,86,0.13)] bg-[var(--button-background)] dark:bg-[var(--button-background-dark)] overflow-hidden"
+    >
+      {/* Header / toggle row — always visible */}
+      <div className="px-4 pt-3.5 pb-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="inline-flex items-center gap-2 rounded-full bg-[var(--accent-light)] dark:bg-[var(--accent-light-dark)] px-2.5 py-1">
+            <span
+              aria-hidden="true"
+              className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-[var(--accent-active)]/15 dark:bg-[var(--accent-active-dark)]/20 text-[var(--accent-active)] dark:text-[var(--accent-active-dark)]"
+            >
+              <Sparkles size={12} strokeWidth={2} />
+            </span>
+            <span className="text-xs font-extrabold uppercase tracking-[0.11em] text-[var(--accent-active)] dark:text-[var(--accent-active-dark)]">
+              {symbol} Recap
+            </span>
+          </div>
+
+          {showCadenceToggle && (
+            <div
+              role="group"
+              aria-label="Recap cadence"
+              className="relative inline-flex items-center bg-gray-100/80 dark:bg-gray-800/40 backdrop-blur-sm rounded-full p-1 gap-1"
+            >
+              <div
+                aria-hidden="true"
+                className="absolute top-1 bottom-1 rounded-full bg-white dark:bg-gray-700 shadow-[0_2px_8px_rgba(0,0,0,0.1),0_1px_2px_rgba(0,0,0,0.06)] dark:shadow-[0_2px_8px_rgba(0,0,0,0.4),0_1px_2px_rgba(0,0,0,0.2)] transition-all duration-500 ease-[cubic-bezier(0.34,1.56,0.64,1)] pointer-events-none"
+                style={{
+                  left: `${cadenceIndicator.left}px`,
+                  width: `${cadenceIndicator.width}px`,
+                }}
+              />
+              {(['daily', 'weekly'] as const).map((value, index) => {
+                const active = cadence === value
+                return (
+                  <span
+                    key={value}
+                    ref={(el) => {
+                      cadenceTabRefs.current[index] = el
+                    }}
+                    role="button"
+                    tabIndex={0}
+                    aria-pressed={active}
+                    onClick={() => setCadence(value)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault()
+                        setCadence(value)
+                      }
+                    }}
+                    className={`relative z-10 px-3 py-1 rounded-full text-xs font-semibold transition-colors duration-300 cursor-pointer select-none whitespace-nowrap ${
+                      active
+                        ? 'text-gray-900 dark:text-white'
+                        : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+                    }`}
+                  >
+                    {value === 'daily' ? 'Daily' : 'Weekly'}
+                  </span>
+                )
+              })}
+            </div>
+          )}
+
+          <button
+            type="button"
+            aria-label={expanded ? 'Collapse recap' : 'Expand recap'}
+            aria-expanded={expanded}
+            onClick={() => setExpanded((prev) => !prev)}
+            className="ml-auto p-1 -mr-1 text-[var(--accent-active)] dark:text-[var(--accent-active-dark)] cursor-pointer"
+          >
+            <span
+              className={`inline-block transition-transform duration-300 ${expanded ? '' : 'rotate-180'}`}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                <polyline
+                  points="18 15 12 9 6 15"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+
+        {/* Period chip */}
+        <div className="mt-3">
+          <span
+            aria-label={`Recap period ${formattedPeriod}`}
+            className="inline-flex items-center gap-1.5 rounded-full border border-[rgba(40,105,86,0.25)] dark:border-[rgba(156,214,194,0.35)] px-2 py-1 text-[11px] font-medium text-gray-600 dark:text-gray-300 whitespace-nowrap"
+          >
+            <CalendarDays aria-hidden="true" size={12} strokeWidth={2.1} />
+            <span className="whitespace-nowrap">{formattedPeriod}</span>
+          </span>
+        </div>
+
+        {/* Summary */}
+        <p className="mt-3 text-base md:text-lg leading-6 md:leading-7 text-gray-700 dark:text-gray-200">
+          {recap.summary}
+        </p>
+
+        {/* Curated timestamp */}
+        {formattedCreatedAt && (
+          <div className="mt-2.5">
+            <span
+              aria-label={`Recap created ${formattedCreatedAt}`}
+              className="inline-flex items-center gap-1.5 rounded-full border border-[rgba(40,105,86,0.25)] dark:border-[rgba(156,214,194,0.35)] px-2 py-1 text-[11px] font-medium text-gray-600 dark:text-gray-300 whitespace-nowrap"
+            >
+              <Clock3 aria-hidden="true" size={12} strokeWidth={2.1} />
+              <span className="whitespace-nowrap">Curated on: {formattedCreatedAt}</span>
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Bullets — collapsible */}
+      <div
+        className="grid transition-[grid-template-rows] duration-300 ease-out"
+        style={{ gridTemplateRows: expanded ? '1fr' : '0fr' }}
+      >
+        <div className="overflow-hidden">
+          <div className="px-4 pb-4">
+            <div className="h-px bg-[rgba(40,105,86,0.12)] mb-3.5" />
+            <div className="space-y-3">
+              {recap.bullets.map((bullet, bulletIndex) => (
+                <div key={`${bullet.text}-${bulletIndex}`} className="flex items-start gap-2.5">
+                  <span
+                    className={`mt-2 h-2 w-2 shrink-0 rounded-full ring-2 ring-white dark:ring-black/25 ${bulletColor(
+                      bulletIndex,
+                    )}`}
+                  />
+                  <div className="flex-1 text-base md:text-lg leading-6 md:leading-7 text-gray-700 dark:text-gray-200">
+                    <span>{bullet.text}</span>
+                    {bullet.citations.map((citation, citationIndex) => {
+                      const source = sourceById.get(citation.source_id)
+                      if (!source?.url) return null
+                      const citationKey = `${bulletIndex}-${citation.source_id}-${citationIndex}`
+                      return (
+                        <span key={citationKey} className="ml-1.5 inline-flex">
+                          <SourceChip
+                            source={{
+                              url: source.url,
+                              title: source.title,
+                              publisher: source.publisher,
+                              publishedAt: source.published_at,
+                            }}
+                          />
+                        </span>
+                      )
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/app/components/TickerRecapIsland.tsx
+++ b/app/components/TickerRecapIsland.tsx
@@ -1,0 +1,24 @@
+import TickerRecapCard from './TickerRecapCard'
+import type { TickerRecapItem } from '@/lib/api/tickerRecap'
+
+/**
+ * Renders the ticker recap card. Data is fetched on the server and passed in as
+ * props; returns nothing when the ticker has no recap.
+ */
+export default function TickerRecapIsland({
+  symbol,
+  daily,
+  weekly,
+}: {
+  symbol: string
+  daily: TickerRecapItem | null
+  weekly: TickerRecapItem | null
+}) {
+  if (!daily && !weekly) return null
+
+  return (
+    <div className="mb-6">
+      <TickerRecapCard symbol={symbol} daily={daily} weekly={weekly} />
+    </div>
+  )
+}

--- a/app/components/__tests__/TickerRecapCard.test.tsx
+++ b/app/components/__tests__/TickerRecapCard.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import TickerRecapCard from '../TickerRecapCard'
+import type { TickerRecapItem } from '@/lib/api/tickerRecap'
+
+const weeklyRecap: TickerRecapItem = {
+  id: 1,
+  period_start: '2026-06-28',
+  period_end: '2026-07-02',
+  created_at: '2026-07-03T05:00:00Z',
+  summary: 'Apple gained 6.2% on the week and finished at a fresh record.',
+  bullets: [
+    { text: 'Shares set new all-time closing highs on Thursday and Friday.', citations: [] },
+    { text: 'Market cap crossed $4.25T.', citations: [{ source_id: 's1' }] },
+  ],
+  sources: [
+    {
+      id: 's1',
+      url: 'https://example.com/1',
+      title: 'Source 1',
+      publisher: 'Reuters',
+      published_at: '2026-07-02T12:00:00Z',
+      fetched_at: '2026-07-03T12:00:00Z',
+    },
+  ],
+  price_change: null,
+}
+
+const dailyRecap: TickerRecapItem = {
+  id: 2,
+  period_start: '2026-07-02',
+  period_end: '2026-07-02',
+  created_at: '2026-07-03T05:00:00Z',
+  summary: 'Apple jumped 4.8% to $308.63 after strong services guidance.',
+  bullets: [{ text: 'Services guidance topped consensus.', citations: [] }],
+  sources: [],
+  price_change: null,
+}
+
+describe('TickerRecapCard', () => {
+  it('renders the ticker-scoped label and summary, expanded by default', () => {
+    render(<TickerRecapCard symbol="AAPL" daily={dailyRecap} weekly={null} />)
+
+    expect(screen.getByText('AAPL Recap')).toBeInTheDocument()
+    expect(screen.getByText(/Apple jumped 4.8%/i)).toBeInTheDocument()
+    // Bullets visible without interaction (expanded by default).
+    expect(screen.getByText(/Services guidance topped consensus/i)).toBeInTheDocument()
+  })
+
+  it('does not render a Dig deeper button', () => {
+    render(<TickerRecapCard symbol="AAPL" daily={dailyRecap} weekly={null} />)
+    expect(screen.queryByRole('button', { name: /dig deeper/i })).not.toBeInTheDocument()
+  })
+
+  it('collapses bullets when the collapse control is toggled', () => {
+    render(<TickerRecapCard symbol="AAPL" daily={dailyRecap} weekly={null} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /collapse recap/i }))
+    expect(screen.getByRole('button', { name: /expand recap/i })).toBeInTheDocument()
+  })
+
+  it('shows the Daily/Weekly toggle only when both cadences exist', () => {
+    const { rerender } = render(
+      <TickerRecapCard symbol="AAPL" daily={dailyRecap} weekly={weeklyRecap} />,
+    )
+    expect(screen.getByRole('button', { name: /^daily$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^weekly$/i })).toBeInTheDocument()
+
+    rerender(<TickerRecapCard symbol="AAPL" daily={dailyRecap} weekly={null} />)
+    expect(screen.queryByRole('button', { name: /^weekly$/i })).not.toBeInTheDocument()
+  })
+
+  it('switches the summary when Weekly is selected', () => {
+    render(<TickerRecapCard symbol="AAPL" daily={dailyRecap} weekly={weeklyRecap} />)
+
+    expect(screen.getByText(/Apple jumped 4.8%/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /^weekly$/i }))
+    expect(screen.getByText(/Apple gained 6.2%/i)).toBeInTheDocument()
+    expect(screen.queryByText(/Apple jumped 4.8%/i)).not.toBeInTheDocument()
+  })
+
+  it('renders period and curated chips, and citation chips using publisher name', () => {
+    render(<TickerRecapCard symbol="AAPL" daily={null} weekly={weeklyRecap} />)
+
+    expect(screen.getByLabelText(/Recap period/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Recap created/i)).toBeInTheDocument()
+    const source = screen.getByRole('link', { name: /reuters/i })
+    expect(source).toHaveAttribute('href', 'https://example.com/1')
+  })
+
+  it('returns null when neither cadence has data', () => {
+    const { container } = render(<TickerRecapCard symbol="AAPL" daily={null} weekly={null} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/app/tickers/[ticker]/page.tsx
+++ b/app/tickers/[ticker]/page.tsx
@@ -8,6 +8,8 @@ import { CompanyFinancialStatement, type CompanyStatementsResponse } from '@/app
 import { Company } from '@/app/CompanyList'
 import PriceChart from './PriceChart'
 import CompanyInfo from './CompanyInfo'
+import TickerRecapIsland from '@/app/components/TickerRecapIsland'
+import { getTickerRecapPair } from '@/lib/api/tickerRecap'
 
 export const revalidate = 30
 
@@ -33,6 +35,8 @@ export default async function TickerDetails({ params }: { params: Promise<{ tick
 
   let keyStats: KeyStatsType | null = null
   let statements: CompanyFinancialStatement[] | null = null
+
+  const recapPair = await getTickerRecapPair(ticker)
 
   try {
     const keyStatsResponse = await fetch(
@@ -106,6 +110,11 @@ export default async function TickerDetails({ params }: { params: Promise<{ tick
       <Suspense fallback={<p>Loading stock price chart</p>}>
         <PriceChart ticker={ticker} />
       </Suspense>
+      <TickerRecapIsland
+        symbol={ticker.toUpperCase()}
+        daily={recapPair.daily}
+        weekly={recapPair.weekly}
+      />
       {keyStats && <KeyStats keyStats={keyStats} />}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
         <Suspense fallback={<p>Loading growth chart...</p>}>

--- a/lib/api/tickerRecap.ts
+++ b/lib/api/tickerRecap.ts
@@ -1,6 +1,9 @@
 import type { RecapBullet, RecapSource } from '@/lib/api/marketRecap'
 import type { PriceChange } from '@/lib/api/quotes'
 
+const BACKEND_URL =
+  process.env.BACKEND_URL || process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8080'
+
 /**
  * Per-ticker precomputed daily recap from the backend.
  * GET /api/companies/{ticker}/recaps?cadence=daily&limit=1
@@ -28,9 +31,54 @@ export type TickerRecapResponse = {
   items: TickerRecapItem[]
 }
 
-/** Fetches the latest daily recap for a ticker from the BFF proxy. Null when none. */
-export async function fetchTickerRecap(ticker: string): Promise<TickerRecapItem | null> {
-  const res = await fetch(`/api/companies/${encodeURIComponent(ticker)}/recaps`)
+export type TickerRecapCadence = 'daily' | 'weekly'
+
+/** Latest daily + weekly recap for a ticker; either may be null when absent. */
+export type TickerRecapPair = {
+  daily: TickerRecapItem | null
+  weekly: TickerRecapItem | null
+}
+
+/** Fetches the latest recap for a ticker/cadence from the BFF proxy. Null when none. */
+export async function fetchTickerRecap(
+  ticker: string,
+  cadence: TickerRecapCadence = 'daily',
+): Promise<TickerRecapItem | null> {
+  const res = await fetch(`/api/companies/${encodeURIComponent(ticker)}/recaps?cadence=${cadence}`)
   if (!res.ok) return null
   return (await res.json()) as TickerRecapItem | null
+}
+
+/**
+ * Server-side: reads one cadence's latest precomputed recap straight from the
+ * backend (not the BFF proxy), so the ticker page can render it during SSR.
+ */
+async function getServerTickerRecap(
+  ticker: string,
+  cadence: TickerRecapCadence,
+): Promise<TickerRecapItem | null> {
+  try {
+    const res = await fetch(
+      `${BACKEND_URL}/api/companies/${ticker}/recaps?cadence=${cadence}&limit=1`,
+      { next: { revalidate: 10 * 60, tags: ['ticker-recaps'] } },
+    )
+    if (!res.ok) return null
+    const json = (await res.json()) as { items?: TickerRecapItem[] }
+    return json.items?.[0] ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Server-side: fetches daily + weekly recaps in parallel for the ticker page.
+ * Each cadence resolves to null independently when the backend has no row.
+ */
+export async function getTickerRecapPair(ticker: string): Promise<TickerRecapPair> {
+  const symbol = ticker.toUpperCase()
+  const [daily, weekly] = await Promise.all([
+    getServerTickerRecap(symbol, 'daily'),
+    getServerTickerRecap(symbol, 'weekly'),
+  ])
+  return { daily, weekly }
 }


### PR DESCRIPTION
## Summary
Renders a per-ticker recap card on the ticker detail page (design: Claude Design "Ticker Recap"). Sits between the price chart and key stats.

- **SSR**: `getTickerRecapPair(ticker)` fetches daily + weekly from the backend server-side; the card ships in the initial HTML (respects `revalidate` + `ticker-recaps` cache tag). No client waterfall.
- **Card** (`TickerRecapCard`): collapsible, Daily/Weekly toggle (hidden when only one cadence exists), period + "Curated on" chips, cited bullets via existing `SourceChip`. Renders nothing for tickers without a recap.
- **BFF route** `GET /api/companies/[ticker]/recaps` now accepts `?cadence=daily|weekly` (defaults `daily`, so the existing watchlist badge caller is unaffected).

## Notes
- No "Dig deeper" chat for now (intentionally omitted).
- Backend already supports `cadence`; weekly ticker rows may not exist yet — the card degrades to daily-only gracefully.

## Test
- `type-check` ✓ · `eslint` ✓ · `test:unit` (197 passed, incl. new `TickerRecapCard` tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)