### PR TITLE
feat(chat): default model selector to Gemini 3.5 Flash

### DIFF
--- a/app/components/ModelSelector.tsx
+++ b/app/components/ModelSelector.tsx
@@ -9,7 +9,7 @@ export interface ModelOption {
 
 const MODEL_OPTIONS: ModelOption[] = [
   { label: 'Lightning', value: 'fastest' },
-  { label: 'Gemini 3.0 Flash', value: 'gemini-3.0-flash' },
+  { label: 'Gemini 3.5 Flash', value: 'gemini-3.5-flash' },
   { label: 'Sonnet 4.6', value: 'sonnet-4.6' },
 ]
 

--- a/app/components/hooks/useChatState.ts
+++ b/app/components/hooks/useChatState.ts
@@ -65,7 +65,9 @@ export const isNormalThread = (thread: Thread): thread is NormalThread => {
 }
 
 const STORAGE_KEY = 'stonkie-preferred-model'
-const DEFAULT_MODEL = 'gemini-3.0-flash'
+const DEFAULT_MODEL = 'gemini-3.5-flash'
+// Deprecated model values that should be migrated to DEFAULT_MODEL on load
+const DEPRECATED_MODELS = new Set(['gemini-3.0-flash'])
 const CONVERSATION_KEY_PREFIX = 'stonkie_conversation_'
 const ACTIVITY_TIMESTAMP_PREFIX = 'stonkie_activity_'
 const INACTIVITY_TIMEOUT_MS = 15 * 60 * 1000 // 15 minutes
@@ -88,7 +90,9 @@ export const useChatState = (ticker: string | undefined) => {
   const [preferredModel, setPreferredModelState] = useState<string>(() => {
     if (typeof window !== 'undefined') {
       const stored = localStorage.getItem(STORAGE_KEY)
-      return stored || DEFAULT_MODEL
+      if (stored && !DEPRECATED_MODELS.has(stored)) {
+        return stored
+      }
     }
     return DEFAULT_MODEL
   })


### PR DESCRIPTION
## Summary
Updates the chat model selector default from **Gemini 3.0 Flash** to **Gemini 3.5 Flash**, pairing with the backend model-routing PR (stock_agent).

## Changes
- `ModelSelector.tsx`: dropdown option `Gemini 3.0 Flash` → **`Gemini 3.5 Flash`** (value `gemini-3.5-flash`)
- `useChatState.ts`: `DEFAULT_MODEL` → `gemini-3.5-flash`
- `useChatState.ts`: added `DEPRECATED_MODELS` migration so returning users with `gemini-3.0-flash` in localStorage roll to the new default on load (avoids silently sticking on 3.0, and the "shows Lightning but sends 3.0" mismatch)

## Notes
- Existing users just need to reload — the localStorage migration handles the stale value automatically.
- "Lightning" and "Sonnet 4.6" options unchanged (Lightning now resolves to 3.1 Flash-Lite Nitro backend-side).

## Verification
- `npm run type-check` clean
- `npm run test:unit` — 200 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)